### PR TITLE
Add option to use GCP managed certificates on proxy ingress

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ However, do not install more than one Fusion release in the same namespace.
 
 == Google Kubernetes Engine (GKE)
 
-Run the `setup_f5_gke.sh` script to install Fusion 5.x in a GKE cluster. Use the `--help` option to see script usage.
+Run the `setup_f5_gke.sh` script to install Fusion 5.x in a GKE cluster. Use the `-help` option to see script usage.
 
 __Note: If not provided the script generates a custom values file named <release>_<namespace>_fusion_values.yaml which you can use to customize the Fusion chart.__
 

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -8,7 +8,7 @@ function print_usage() {
     echo -e "\nERROR: $ERROR_MSG"
   fi
 
-  echo -e "\nUse this script to install Fusion 5 on GKE; optionally create a GKE cluster in the process\n"
+  echo -e "\nUse this script to install Fusion 5 on GKE; optionally create a GKE cluster in the process"
   echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
   echo -e "  -c          Name of the GKE cluster (required)\n"
   echo -e "  -p          GCP Project ID (required)\n"
@@ -18,12 +18,12 @@ function print_usage() {
   echo -e "  -b          GCS Bucket for storing ML models\n"
   echo -e "  -i          Instance type, defaults to 'n1-standard-4'\n"
   echo -e "  -t          Enable TLS for the ingress, requires a hostname to be specified with -h\n"
-  echo -e "  -h          Hostname for the ingress to route requests to this Fusion cluster. If used with the -t parameter the hostname must be a public DNS record that can be updated to point to the IP of the LoadBalancer\n"
-  echo -e "  --version   Fusion Helm Chart version\n"
-  echo -e "  --values    Custom values file containing config overrides; defaults to custom_fusion_values.yaml\n"
-  echo -e "  --create    Create a cluster in GKE; provide the mode of the cluster to create, one of: demo, multi_az, node_pools\n"
+  echo -e "  -h          Hostname for the ingress to route requests to this Fusion cluster. If used with the -t parameter,\n              then the hostname must be a public DNS record that can be updated to point to the IP of the LoadBalancer\n"
+  echo -e "  --version   Fusion Helm Chart version; defaults to the latest release from Lucidworks, such as 5.0.0\n"
+  echo -e "  --values    Custom values file containing config overrides; defaults to <release>_<namespace>_fusion_values.yaml\n"
+  echo -e "  --create    Create a cluster in GKE; provide the mode of the cluster to create, one of: demo, multi_az\n"
   echo -e "  --upgrade   Perform a Helm upgrade on an existing Fusion installation\n"
-  echo -e "  --purge     Uninstall and purge all Fusion objects from the specified namespace and cluster\n"
+  echo -e "  --purge     Uninstall and purge all Fusion objects from the specified namespace and cluster.\n              Be careful! This operation cannot be undone.\n"
 }
 
 SCRIPT_CMD="$0"

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -9,7 +9,7 @@ function print_usage() {
   fi
 
   echo -e "\nUse this script to install Fusion 5 on GKE; optionally create a GKE cluster in the process\n"
-  echo -e "\nUsage: $CMD -c <cluster> -r <release> -n <namespace> -p <project> -z <zone> -i <instance_type> --values <values> --create <mode> --upgrade --purge\n"
+  echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
   echo -e "  -c          Name of the GKE cluster (required)\n"
   echo -e "  -p          GCP Project ID (required)\n"
   echo -e "  -r          Helm release name for installing Fusion 5, defaults to 'f5'\n"
@@ -18,7 +18,7 @@ function print_usage() {
   echo -e "  -b          GCS Bucket for storing ML models\n"
   echo -e "  -i          Instance type, defaults to 'n1-standard-4'\n"
   echo -e "  -t          Enable TLS for the ingress, requires a hostname to be specified with -h\n"
-  echo -e "  -h          Hostname for the ingress to route requests to this fusion cluster. If used with the -t parameter the hostname must be a public DNS record that can be updated to point to the IP of the LoadBalancer\n"
+  echo -e "  -h          Hostname for the ingress to route requests to this Fusion cluster. If used with the -t parameter the hostname must be a public DNS record that can be updated to point to the IP of the LoadBalancer\n"
   echo -e "  --version   Fusion Helm Chart version\n"
   echo -e "  --values    Custom values file containing config overrides; defaults to custom_fusion_values.yaml\n"
   echo -e "  --create    Create a cluster in GKE; provide the mode of the cluster to create, one of: demo, multi_az, node_pools\n"
@@ -413,7 +413,6 @@ END
 fi
 
 helm repo update
-
 
 ADDITIONAL_VALUES=""
 if [ "${TLS_ENABLED}" == "1" ]; then

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -68,7 +68,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             NAMESPACE="$2"
-            MY_VALUES=${RELEASE}_${NAMESPACE}_fusion_values.yaml
+            MY_VALUES="${RELEASE}_${NAMESPACE}_fusion_values.yaml"
             shift 2
         ;;
         -p)
@@ -85,6 +85,7 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             RELEASE="$2"
+            MY_VALUES="${RELEASE}_${NAMESPACE}_fusion_values.yaml"
             shift 2
         ;;
         -z)
@@ -182,7 +183,7 @@ if [ "$GCLOUD_PROJECT" == "" ]; then
   exit 1
 fi
 
-if [ "$CUSTOM_MY_VALUES" != "" ]; then
+if [ -n "$CUSTOM_MY_VALUES" ]; then
   MY_VALUES=$CUSTOM_MY_VALUES
 fi
 


### PR DESCRIPTION
This PR:
  - Adds an option to configure a GCP ingress with a a TLS certificate. This requires that a public DNS record can be created that points to the IP of the LB. GCP will then automatically provision a certificate.