### PR TITLE
Added logstashEnabled to values that are passed into the helm chart

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -1,4 +1,5 @@
 cx-ui:
+  logstashEnabled: true
   replicaCount: 1
   resources:
     limits:
@@ -41,6 +42,7 @@ solr:
       ZK_HEAP_SIZE: 1G
 
 ml-model-service:
+  logstashEnabled: true
   modelRepository:
     impl: fs
     gcs:
@@ -48,13 +50,34 @@ ml-model-service:
       baseDirectoryName: dev
 
 fusion-admin:
+  logstashEnabled: true
   readinessProbe:
     initialDelaySeconds: 180
 
 fusion-indexing:
+  logstashEnabled: true
   readinessProbe:
     initialDelaySeconds: 180
 
+api-gateway:
+  logstashEnabled: true
+
+classic-rest-service:
+  logstashEnabled: true
+
+rest-service:
+  logstashEnabled: true
+
+rpc-service:
+  logstashEnabled: true
+
+job-launcher:
+  logstashEnabled: true
+
+job-rest-server:
+  logstashEnabled: true
+
 query-pipeline:
+  logstashEnabled: true
   javaToolOptions: "-Dlogging.level.com.lucidworks.cloud=INFO"
 


### PR DESCRIPTION
Adds the `logstashEnabled` flag to our Fusion deployment script, which can be toggled to disabled in our values.yaml file. 