### PR TITLE
Ensure that the loadbalancer IP is available before printing the TLS message

### DIFF
--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -420,6 +420,7 @@ function ingress_setup() {
       export INGRESS_IP="${ingressIp}"
       break
     fi
+    loops=$(( loops - 1 ))
     echo -ne "."
     sleep 5
   done

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -413,7 +413,7 @@ function ingress_setup() {
   # Patch yaml for now, until fix gets into helm charts
   kubectl patch --namespace "${NAMESPACE}" ingress "${RELEASE}-api-gateway" -p "{\"spec\":{\"rules\":[{\"host\": \"${INGRESS_HOSTNAME}\", \"http\":{\"paths\":[{\"backend\": {\"serviceName\": \"proxy\", \"servicePort\": 6764}, \"path\": \"/*\"}]}}]}}"
   echo -ne "\nWaiting for the Loadbalancer IP to be assigned"
-  loops=10
+  loops=24
   while (( loops > 0 )); do
     ingressIp=$(kubectl --namespace "${NAMESPACE}" get ingress "${RELEASE}-api-gateway" -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     if [[ ! -z ${ingressIp} ]]; then


### PR DESCRIPTION
This PR:
  - Waits up to 50 seconds for the GCP Loadbalancer Ingress to have been assigned an IP before printing the message informing the user that they have to update the DNS record.