### PR TITLE
Add stable helm repo and move zookeeper to top leve configuration

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -27,16 +27,17 @@ solr:
       prometheus.io/path: "/metrics"
     nodeSelector:
       {NODE_POOL}
-  zookeeper:
-    nodeSelector:
-      {NODE_POOL}
-    replicaCount: {SOLR_REPLICAS}
-    persistence:
-      size: 15Gi
-    resources: {}
-    env:
-      ZK_HEAP_SIZE: 1G
-      ZK_PURGE_INTERVAL: 1
+
+zookeeper:
+  nodeSelector:
+    {NODE_POOL}
+  replicaCount: {SOLR_REPLICAS}
+  persistence:
+    size: 15Gi
+  resources: {}
+  env:
+    ZK_HEAP_SIZE: 1G
+    ZK_PURGE_INTERVAL: 1
 
 ml-model-service:
   image:

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -331,6 +331,11 @@ if ! helm repo list | grep -q "https://charts.lucidworks.com"; then
   helm repo add ${lw_helm_repo} https://charts.lucidworks.com
 fi
 
+if ! helm repo list | grep -q "https://kubernetes-charts.storage.googleapis.com"; then
+  echo -e "\nAdding the stable chart repo to helm repo list"
+  helm repo add stable https://kubernetes-charts.storage.googleapis.com
+fi
+
 # If no custom values are passed, and we are not upgrading, then supply a default values yaml
 if [ -z $CUSTOM_MY_VALUES ] && [ "$UPGRADE" != "1" ]; then
   if [ ! -f "${DEFAULT_MY_VALUES}" ]; then


### PR DESCRIPTION
This PR:
  - Moves zookeeper configuration to be top level instead of being under `solr` this fixes an issue when installing fusion 5.0.2 where it would fail with:
```
Error: template: fusion/charts/solr/templates/_helpers.tpl:56:125: executing "solr.zookeeper-connection-string" at <$.Values.zookeeper.service.ports.client.port>: nil pointer evaluating interface {}.ports
```
  - Adds a check for the `stable` helm repository, which is not enabled by default in helm v3