### PR TITLE
Add missing --profile and add path to tls-setup

### DIFF
--- a/setup_f5_eks.sh
+++ b/setup_f5_eks.sh
@@ -308,7 +308,7 @@ else
   fi
 fi
 
-aws eks --region "${REGION}" update-kubeconfig --name "${CLUSTER_NAME}"
+aws eks --profile "${AWS_ACCOUNT}" --region "${REGION}" update-kubeconfig --name "${CLUSTER_NAME}"
 current_cluster=$(kubectl config current-context)
 
 if [ "$PURGE" == "1" ]; then
@@ -398,4 +398,3 @@ source ./setup_f5_k8s.sh -c $CLUSTER_NAME -r "${RELEASE}" --provider "eks" -n "$
   --version ${CHART_VERSION} --prometheus ${PROMETHEUS} ${VALUES_STRING}${INGRESS_ARG}${UPGRADE_ARGS}
 setup_result=$?
 exit $setup_result
-

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -389,6 +389,7 @@ api-gateway:
   ingress:
     enabled: true
     host: "${INGRESS_HOSTNAME}"
+    path: "/*"
     tls:
       enabled: true
     annotations:
@@ -431,7 +432,7 @@ if [ ! -z "${INGRESS_VALUES}" ]; then
       --num-solr $SOLR_REPLICAS --solr-disk-gb $SOLR_DISK_GB --node-pool "${NODE_POOL}"
     VALUES_STRING="--values ${DEFAULT_MY_VALUES}"
   fi
-  
+
   VALUES_STRING="${VALUES_STRING} ${INGRESS_VALUES}"
 fi
 


### PR DESCRIPTION
This PR:
  - Adds `path: /*` to the tls setup for `gke` 
  - Adds `--profile "${AWS_ACCOUNT}"` when updating kubeconfig for eks clusters