### PR TITLE
Add documentation for configuring timeouts in GKE and nginx ingress

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -178,9 +178,41 @@ kubectl get managedcertificates -n <namespace> -o yaml
 
 Please refer to the Kubernetes documentation on configuring an Ingress for GKE: https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer[Setting up HTTP Load Balancing with Ingress]
 
-NOTE: The GCP Ingress defaults to a 30 second timeout, which can lead to false negatives for long running requests such as importing apps. Use the instructions on this page to increase the timeout:
-https://cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+NOTE: The GCP Ingress defaults to a 30 second timeout, which can lead to false negatives for long running requests such as importing apps. To configure the timeout for the backend in kubernetes:
 
+Create a BackendConfig object in your namespace:
+
+```
+---
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: backend_config_name
+spec:
+  timeoutSec: 120
+  connectionDraining:
+    drainingTimeoutSec: 60
+```
+
+Then make sure that the following entries are in the right place in your values.yaml file:
+
+```
+api-gateway:
+  service:
+    annotations:
+      beta.cloud.google.com/backend-config: '{"ports": {"6764":"backend_config_name"}}'
+```
+
+==== Considerations when using the nginx ingress controller
+
+If you are using the `nginx` ingress controller to fulfil your ingress definitions there are a couple
+of options that are recommended to be set in the configmap:
+
+```
+enable-underscores-in-headers: "true"   # Fusion can return some headers that have underscores, these have to be explicitly enabled in nginx
+proxy-body-size: "0"        # By default nginx places a maximum size on request bodies, either increase as needed or disable by setting to 0
+proxy-read-timeout: "300"   # Increases the timeout for potential slow queries.
+```
 ==== Custom values
 
 There are some example values files that can be used as a starting point for

--- a/README.adoc
+++ b/README.adoc
@@ -203,6 +203,8 @@ api-gateway:
       beta.cloud.google.com/backend-config: '{"ports": {"6764":"backend_config_name"}}'
 ```
 
+and upgrade your release to apply the configuration changes
+
 ==== Considerations when using the nginx ingress controller
 
 If you are using the `nginx` ingress controller to fulfil your ingress definitions there are a couple

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -259,9 +259,16 @@ elif [ "$PURGE" == "1" ]; then
   exit 0
 else
   # Check if there is already a release for helm with the release name that we want
-  if helm status "${RELEASE}" > /dev/null 2>&1 ; then
-    echo -e "\nERROR: There is already a release with name: ${RELEASE} installed in the cluster, please choose a different release name or upgrade the release\n"
-    exit 1
+  if [ "${is_helm_v3}" == "" ]; then
+    if helm status "${RELEASE}" > /dev/null 2>&1 ; then
+      echo -e "\nERROR: There is already a release with name: ${RELEASE} installed in the cluster, please choose a different release name or upgrade the release\n"
+      exit 1
+    fi
+  else
+     if helm status --namespace "${NAMESPACE}" "${RELEASE}" > /dev/null 2>&1 ; then
+       echo -e "\nERROR: There is already a release with name: ${RELEASE} installed in namespace: ${NAMESPACE} in the cluster, please choose a different release name or upgrade the release\n"
+       exit 1
+     fi
   fi
 
   # There isn't let's check if there is a fusion deployment in the namespace already


### PR DESCRIPTION
This PR:
  - Adds documentation for configuring the timeout for a GKE ingress
  - Adds a note on configuration options to set if running with an `nginx` ingress controller
  - Fixes an issue in purge with helm 3 where the purge would fail if not using the default namespace.