### PR TITLE
Add a source_label to drop all metrics outside of the installed namespace

### DIFF
--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -146,6 +146,7 @@ if [ "$PROMETHEUS_ON" == "true" ]; then
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
     sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}\n"
   fi
 
@@ -156,4 +157,3 @@ if [ "$PROMETHEUS_ON" == "true" ]; then
     echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}\n"
   fi
 fi
-

--- a/example-values/prometheus-values.yaml
+++ b/example-values/prometheus-values.yaml
@@ -33,6 +33,9 @@ serverFiles:
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: true
+          - source_labels: [__meta_kubernetes_namespace]
+            action: keep
+            regex: "^{NAMESPACE}$"
           - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: ([^:]+)(?::\d+)?;(\d+)

--- a/install_prom.sh
+++ b/install_prom.sh
@@ -116,6 +116,7 @@ PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
 if [ ! -f "${PROMETHEUS_VALUES}" ]; then
   cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
   sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+  sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
   echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
 fi
 
@@ -135,4 +136,3 @@ helm upgrade ${RELEASE}-graf stable/grafana --install --namespace "${NAMESPACE}"
 kubectl rollout status deployments/${RELEASE}-graf-grafana --timeout=60s --namespace "${NAMESPACE}"
 
 echo -e "\n\nSuccessfully installed Prometheus (${RELEASE}-prom) and Grafana (${RELEASE}-graf) into the ${NAMESPACE} namespace.\n"
-

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -399,6 +399,7 @@ if [ "$UPGRADE" != "1" ] && [ "${PROMETHEUS}" != "none" ]; then
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
     sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
   fi
 


### PR DESCRIPTION
This PR:
  - Adds a stage to the prometheus server endpoint discovery to not scrape metrics from outside of the namespace that it is installed into when installed with the default prometheus values.