### PR TITLE
Default release to the namespace

### DIFF
--- a/setup_f5_aks.sh
+++ b/setup_f5_aks.sh
@@ -9,7 +9,6 @@ AKS_KUBE_CONFIG="${KUBECONFIG:-~/.kube/config}"
 SCRIPT_CMD="$0"
 AZURE_RESOURCE_GROUP=
 CLUSTER_NAME=
-RELEASE=f5
 NAMESPACE=default
 UPGRADE=0
 PURGE=0
@@ -225,6 +224,16 @@ if [[ $NAMESPACE =~ [^$valid] ]]; then
   echo -e "\nERROR: Namespace $NAMESPACE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1
 fi
+
+if [ -z ${RELEASE+x} ]; then
+  # keep "f5" as the default for legacy purposes when using the default namespace
+  if [ "${NAMESPACE}" == "default" ]; then
+    RELEASE="f5"
+  else
+    RELEASE="$NAMESPACE"
+  fi
+fi
+
 if [[ $RELEASE =~ [^$valid] ]]; then
   echo -e "\nERROR: Release $RELEASE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1

--- a/setup_f5_eks.sh
+++ b/setup_f5_eks.sh
@@ -9,7 +9,6 @@ SCRIPT_CMD="$0"
 AWS_ACCOUNT=
 REGION=us-west-2
 CLUSTER_NAME=
-RELEASE=f5
 NAMESPACE=default
 UPGRADE=0
 CREATE_MODE=
@@ -217,6 +216,16 @@ if [[ $NAMESPACE =~ [^$valid] ]]; then
   echo -e "\nERROR: Namespace $NAMESPACE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1
 fi
+
+if [ -z ${RELEASE+x} ]; then
+  # keep "f5" as the default for legacy purposes when using the default namespace
+  if [ "${NAMESPACE}" == "default" ]; then
+    RELEASE="f5"
+  else
+    RELEASE="$NAMESPACE"
+  fi
+fi
+
 if [[ $RELEASE =~ [^$valid] ]]; then
   echo -e "\nERROR: Release $RELEASE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -9,7 +9,6 @@ SCRIPT_CMD="$0"
 GCLOUD_PROJECT=
 GCLOUD_ZONE=us-west1
 CLUSTER_NAME=
-RELEASE=f5
 NAMESPACE=default
 UPGRADE=0
 GCS_BUCKET=
@@ -35,7 +34,7 @@ function print_usage() {
   echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
   echo -e "  -c            Name of the GKE cluster (required)\n"
   echo -e "  -p            GCP Project ID (required)\n"
-  echo -e "  -r            Helm release name for installing Fusion 5, defaults to 'f5'\n"
+  echo -e "  -r            Helm release name for installing Fusion 5; defaults to the namespace, see -n option\n"
   echo -e "  -n            Kubernetes namespace to install Fusion 5 into, defaults to 'default'\n"
   echo -e "  -z            GCP Zone to launch the cluster in, defaults to 'us-west1'\n"
   echo -e "  -i            Instance type, defaults to '${INSTANCE_TYPE}'\n"
@@ -247,6 +246,14 @@ valid="0-9a-zA-Z_\-"
 if [[ $NAMESPACE =~ [^$valid] ]]; then
   echo -e "\nERROR: Namespace $NAMESPACE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1
+fi
+if [ -z ${RELEASE+x} ]; then
+  # keep "f5" as the default for legacy purposes when using the default namespace
+  if [ "${NAMESPACE}" == "default" ]; then
+    RELEASE="f5"
+  else
+    RELEASE="$NAMESPACE"
+  fi
 fi
 if [[ $RELEASE =~ [^$valid] ]]; then
   echo -e "\nERROR: Release $RELEASE must only contain 0-9, a-z, A-Z, underscore or dash!\n"

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -9,7 +9,6 @@ INGRESS_HOSTNAME=""
 PROMETHEUS="install"
 SCRIPT_CMD="$0"
 CLUSTER_NAME=
-RELEASE=f5
 NAMESPACE=default
 UPGRADE=0
 PURGE=0
@@ -171,6 +170,16 @@ if [[ $NAMESPACE =~ [^$valid] ]]; then
   echo -e "\nERROR: Namespace $NAMESPACE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1
 fi
+
+if [ -z ${RELEASE+x} ]; then
+  # keep "f5" as the default for legacy purposes when using the default namespace
+  if [ "${NAMESPACE}" == "default" ]; then
+    RELEASE="f5"
+  else
+    RELEASE="$NAMESPACE"
+  fi
+fi
+
 if [[ $RELEASE =~ [^$valid] ]]; then
   echo -e "\nERROR: Release $RELEASE must only contain 0-9, a-z, A-Z, underscore or dash!\n"
   exit 1


### PR DESCRIPTION
new logic:
1) if they don't pass `-n`  or `-r` at all, then default to `namespace=default` and `release=f5` as we have now, 
2) if they pass `-n` but no `-r` , then default the RELEASE to the value passed for -n