### PR TITLE
remove space after -i as it leads to errors on linux

### DIFF
--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -133,11 +133,11 @@ if [ "${NODE_POOL}" == "" ]; then
 fi
 
 cp customize_fusion_values.yaml.example $MY_VALUES
-sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
-sed -i ''  -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
-sed -i ''  -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
-sed -i ''  -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
-sed -i ''  -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
+sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
+sed -i''  -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
+sed -i''  -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
+sed -i''  -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
+sed -i''  -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
 
 echo -e "\nCreated Fusion custom values yaml: ${MY_VALUES}\n"
 
@@ -145,15 +145,15 @@ if [ "$PROMETHEUS_ON" == "true" ]; then
   PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-    sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-    sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}\n"
   fi
 
   GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
   if [ ! -f "${GRAFANA_VALUES}" ]; then
     cp example-values/grafana-values.yaml $GRAFANA_VALUES
-    sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
     echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}\n"
   fi
 fi

--- a/install_prom.sh
+++ b/install_prom.sh
@@ -115,15 +115,15 @@ fi
 PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
 if [ ! -f "${PROMETHEUS_VALUES}" ]; then
   cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-  sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-  sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+  sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+  sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
   echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
 fi
 
 GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
 if [ ! -f "${GRAFANA_VALUES}" ]; then
   cp example-values/grafana-values.yaml $GRAFANA_VALUES
-  sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+  sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
   echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}. Keep this file handy as you'll need it to customize your Grafana installation.\n"
 fi
 

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -379,7 +379,7 @@ INGRESS_VALUES=""
 if [ "${TLS_ENABLED}" == "1" ]; then
 
   # need to create the namespace if it doesn't exist yet
-  if ! kubectl get namespace "${NAMESPACE}" > /dev/null; then
+  if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
     if [ "${UPGRADE}" != "1" ]; then
       kubectl create namespace "${NAMESPACE}"
       kubectl label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -417,15 +417,15 @@ if [ "$UPGRADE" != "1" ] && [ "${PROMETHEUS}" != "none" ]; then
   PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-    sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-    sed -i ''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
   fi
 
   GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
   if [ ! -f "${GRAFANA_VALUES}" ]; then
     cp example-values/grafana-values.yaml $GRAFANA_VALUES
-    sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
     echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}. Keep this file handy as you'll need it to customize your Grafana installation.\n"
   fi
 
@@ -514,9 +514,9 @@ kubectl config set-context --current --namespace=${NAMESPACE}
 
 UPGRADE_SCRIPT="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_upgrade_fusion.sh"
 cp upgrade_fusion.sh.example $UPGRADE_SCRIPT
-sed -i ''  -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
-sed -i ''  -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
-sed -i ''  -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
-sed -i ''  -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
-sed -i ''  -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
+sed -i''  -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
+sed -i''  -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
+sed -i''  -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
+sed -i''  -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
+sed -i''  -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
 echo -e "\nCreating $UPGRADE_SCRIPT for upgrading you Fusion cluster. Please keep this script along with your custom values yaml file(s) in version control.\n"


### PR DESCRIPTION
On Linux, calling `sed -i ''` leads to output like this:
```
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
sed: can't read : No such file or directory
```
Removing the space after `-i` seems to fix.