### PR TITLE
add ability to destroy underlying cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -461,6 +461,14 @@ api-gateway:
 
 After making changes to the custom values yaml file, run an upgrade on the Fusion Helm chart.
 
+=== Delete a Fusion cluster from GKE
+
+Run the https://github.com/lucidworks/fusion-cloud-native/blob/master/destroy_f5_gke.sh[`destroy_f5_gke.sh` script^] to delete Fusion 5.x along with its GKE cluster.
+To delete your gke cluster, simply do:
+```
+./destroy_f5_gke.sh -c <cluster_name> -p <gcp_project_id> -n <namespace>
+```
+
 // end::gke[]
 
 == Amazon Elastic Kubernetes Service (EKS)

--- a/destroy_f5_gke.sh
+++ b/destroy_f5_gke.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+SCRIPT_CMD="$0"
+GCLOUD_PROJECT=
+GCLOUD_ZONE=us-west1
+CLUSTER_NAME=
+NAMESPACE=default
+CLUSTER_TYPE=regional
+
+function print_usage() {
+  CMD="$1"
+  ERROR_MSG="$2"
+
+  if [ "$ERROR_MSG" != "" ]; then
+    echo -e "\nERROR: $ERROR_MSG"
+  fi
+
+  echo -e "\nUse this script to destroy Fusion 5 along with GKE"
+  echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
+  echo -e "  -c            Name of the GKE cluster (required)\n"
+  echo -e "  -p            GCP Project ID (required)\n"
+  echo -e "  -n            Kubernetes namespace to install Fusion 5 into, defaults to 'default'\n"
+  echo -e "  -z            GCP Zone to launch the cluster in, defaults to 'us-west1'\n"
+}
+
+if [ $# -gt 0 ]; then
+  while true; do
+    case "$1" in
+        -c)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -c parameter!"
+              exit 1
+            fi
+            CLUSTER_NAME="$2"
+            shift 2
+        ;;
+        -p)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -p parameter!"
+              exit 1
+            fi
+            GCLOUD_PROJECT="$2"
+            shift 2
+        ;;
+        -n)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -n parameter!"
+              exit 1
+            fi
+            NAMESPACE="$2"
+            shift 2
+        ;;
+        -t)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -t parameter!"
+              exit 1
+            fi
+            CLUSTER_TYPE="$2"
+            shift 2
+        ;;
+        -z)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -z parameter!"
+              exit 1
+            fi
+            GCLOUD_ZONE="$2"
+            shift 2
+        ;;
+        -help|-usage|--help|--usage)
+            print_usage "$SCRIPT_CMD"
+            exit 0
+        ;;
+        --)
+            shift
+            break
+        ;;
+        *)
+            if [ "$1" != "" ]; then
+              print_usage "$SCRIPT_CMD" "Unrecognized or misplaced argument: $1!"
+              exit 1
+            else
+              break # out-of-args, stop looping
+            fi
+        ;;
+    esac
+  done
+fi
+
+# Uninstall and purge all Fusion objects from the specified namespace and cluster."
+./setup_f5_gke.sh -c $CLUSTER_NAME -p $GCLOUD_PROJECT -n $NAMESPACE -z $GCLOUD_ZONE --purge
+
+# Destroy underlying GKE cluster for Fusion 5
+gcloud beta container clusters list --filter="${CLUSTER_NAME}" | grep "${CLUSTER_NAME}" > /dev/null 2>&1
+cluster_status=$?
+if [ "$cluster_status" == "0" ]; then
+  if [ "$CLUSTER_TYPE" = "regional" ]; then
+    gcloud container clusters delete $CLUSTER_NAME --region $GCLOUD_ZONE --project $GCLOUD_PROJECT
+  else
+    gcloud container clusters delete $CLUSTER_NAME --zone $GCLOUD_ZONE --project $GCLOUD_PROJECT
+  fi
+else
+  echo -e "\nCluster '${CLUSTER_NAME}' doesn't exists."
+fi
+
+setup_result=$?
+exit $setup_result


### PR DESCRIPTION
trying to add a script to utilize `./setup_f5_gke.sh ... --purge` along with gcloud command to delete fusion k8s objects and destroy underlying gke cluster as well.

Overall output is shown below.

```
./destroy_f5_gke.sh -c meng-f5 -p cloud-ops-testing -n meng -z us-central1

Logged in as: xxx@lucidworks.com

Cluster 'meng-f5' exists, starting to install Lucidworks Fusion
Fetching cluster endpoint and auth data.
kubeconfig entry generated for meng-f5.

Using kubeconfig: gke_cloud-ops-testing_us-central1_meng-f5

Using Helm v3 (v3.0.3+gac925eb)
NAME   STATUS   AGE
meng   Active   89m
Are you sure you want to purge the meng release from the meng namespace in: gke_cloud-ops-testing_us-central1_meng-f5? This operation cannot be undone! Y/n Y
release "meng" uninstalled
release "meng-prom" uninstalled
release "meng-graf" uninstalled
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
No resources found
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
Error from server (NotFound): jobs.batch "meng-api-gateway" not found
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
No resources found
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
persistentvolumeclaim "classic-rest-service-data-claim-meng-classic-rest-service-0" force deleted
error: timed out waiting for the condition on persistentvolumeclaims/classic-rest-service-data-claim-meng-classic-rest-service-0
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
persistentvolumeclaim "data-meng-logstash-0" force deleted
persistentvolumeclaim "data-meng-zookeeper-0" force deleted
error: timed out waiting for the condition on persistentvolumeclaims/data-meng-logstash-0
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
persistentvolumeclaim "classic-rest-service-data-claim-meng-classic-rest-service-0" force deleted
persistentvolumeclaim "meng-solr-pvc-meng-solr-0" force deleted
error: timed out waiting for the condition on persistentvolumeclaims/classic-rest-service-data-claim-meng-classic-rest-service-0
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
persistentvolumeclaim "storage-volume-meng-prom-prometheus-server-0" force deleted
Error from server (NotFound): serviceaccounts "meng-api-gateway-jks-create" not found
warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.
namespace "meng" force deleted
error: timed out waiting for the condition on namespaces/meng
CLUSTER_TYPE: regional
The following clusters will be deleted.
 - [meng-f5] in [us-central1]

Do you want to continue (Y/n)?  Y

Deleting cluster meng-f5...done.
Deleted [https://container.googleapis.com/v1/projects/cloud-ops-testing/zones/us-central1/clusters/meng-f5].
```