### PR TITLE
APOLLO-23485: Add sed fixes depending on the OS

### DIFF
--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -133,27 +133,43 @@ if [ "${NODE_POOL}" == "" ]; then
 fi
 
 cp customize_fusion_values.yaml.example $MY_VALUES
-sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
-sed -i''  -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
-sed -i''  -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
-sed -i''  -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
-sed -i''  -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
-
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
+  sed -i -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
+  sed -i -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
+  sed -i -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
+  sed -i -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
+else
+  sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
+  sed -i '' -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
+  sed -i '' -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
+  sed -i '' -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
+  sed -i '' -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
+fi
 echo -e "\nCreated Fusion custom values yaml: ${MY_VALUES}\n"
 
 if [ "$PROMETHEUS_ON" == "true" ]; then
   PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-    sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+      sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+      sed -i -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    else
+      sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+      sed -i '' -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    fi
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}\n"
   fi
 
   GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
   if [ ! -f "${GRAFANA_VALUES}" ]; then
     cp example-values/grafana-values.yaml $GRAFANA_VALUES
-    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+      sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    else
+      sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    fi
     echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}\n"
   fi
 fi

--- a/install_prom.sh
+++ b/install_prom.sh
@@ -115,15 +115,24 @@ fi
 PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
 if [ ! -f "${PROMETHEUS_VALUES}" ]; then
   cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-  sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-  sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+  else
+    sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+    sed -i '' -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+  fi
   echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
 fi
 
 GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
 if [ ! -f "${GRAFANA_VALUES}" ]; then
   cp example-values/grafana-values.yaml $GRAFANA_VALUES
-  sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+  else
+    sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+  fi
   echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}. Keep this file handy as you'll need it to customize your Grafana installation.\n"
 fi
 

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -417,15 +417,24 @@ if [ "$UPGRADE" != "1" ] && [ "${PROMETHEUS}" != "none" ]; then
   PROMETHEUS_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_prom_values.yaml"
   if [ ! -f "${PROMETHEUS_VALUES}" ]; then
     cp example-values/prometheus-values.yaml $PROMETHEUS_VALUES
-    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
-    sed -i''  -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+      sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+      sed -i -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    else
+      sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$PROMETHEUS_VALUES"
+      sed -i '' -e "s|{NAMESPACE}|${NAMESPACE}|g" "$PROMETHEUS_VALUES"
+    fi
     echo -e "\nCreated Prometheus custom values yaml: ${PROMETHEUS_VALUES}. Keep this file handy as you'll need it to customize your Prometheus installation.\n"
   fi
 
   GRAFANA_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_graf_values.yaml"
   if [ ! -f "${GRAFANA_VALUES}" ]; then
     cp example-values/grafana-values.yaml $GRAFANA_VALUES
-    sed -i''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+      sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    else
+      sed -i ''  -e "s|{NODE_POOL}|${NODE_POOL}|g" "$GRAFANA_VALUES"
+    fi
     echo -e "\nCreated Grafana custom values yaml: ${GRAFANA_VALUES}. Keep this file handy as you'll need it to customize your Grafana installation.\n"
   fi
 
@@ -514,9 +523,17 @@ kubectl config set-context --current --namespace=${NAMESPACE}
 
 UPGRADE_SCRIPT="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_upgrade_fusion.sh"
 cp upgrade_fusion.sh.example $UPGRADE_SCRIPT
-sed -i''  -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
-sed -i''  -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
-sed -i''  -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
-sed -i''  -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
-sed -i''  -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  sed -i -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
+  sed -i -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
+  sed -i -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
+  sed -i -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
+  sed -i -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
+else
+  sed -i '' -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
+  sed -i '' -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
+  sed -i '' -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
+  sed -i '' -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
+  sed -i '' -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
+fi
 echo -e "\nCreating $UPGRADE_SCRIPT for upgrading you Fusion cluster. Please keep this script along with your custom values yaml file(s) in version control.\n"


### PR DESCRIPTION
Linux uses GNU sed while macOS uses BSD sed, this causes problems and creates unnecessary backup files in macOS clients.

@ian-thebridge-lucidworks has tested this in his local, no extra files were created.

I have tested it in my ubuntu local machine and it works.
