### PR TITLE
Change zookeeper replica handling

### DIFF
--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -132,16 +132,23 @@ if [ "${NODE_POOL}" == "" ]; then
   fi
 fi
 
+ZK_REPLICAS=1
+if (( SOLR_REPLICAS > 2 )); then 
+  ZK_REPLICAS=3
+fi
+
 cp customize_fusion_values.yaml.example $MY_VALUES
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
   sed -i -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
+  sed -i -e "s|{ZK_REPLICAS}|${ZK_REPLICAS}|g" "$MY_VALUES"
   sed -i -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
   sed -i -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
   sed -i -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"
 else
   sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "$MY_VALUES"
   sed -i '' -e "s|{SOLR_REPLICAS}|${SOLR_REPLICAS}|g" "$MY_VALUES"
+  sed -i '' -e "s|{ZK_REPLICAS}|${ZK_REPLICAS}|g" "$MY_VALUES"
   sed -i '' -e "s|{RELEASE}|${RELEASE}|g" "$MY_VALUES"
   sed -i '' -e "s|{PROMETHEUS}|${PROMETHEUS_ON}|g" "$MY_VALUES"
   sed -i '' -e "s|{SOLR_DISK_GB}|${SOLR_DISK_GB}|g" "$MY_VALUES"

--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -1,5 +1,5 @@
 global:
-  zkReplicaCount: {SOLR_REPLICAS}
+  zkReplicaCount: {ZK_REPLICAS}
 
 sql-service:
   enabled: false
@@ -35,7 +35,7 @@ solr:
 zookeeper:
   nodeSelector:
     {NODE_POOL}
-  replicaCount: {SOLR_REPLICAS}
+  replicaCount: {ZK_REPLICAS}
   persistence:
     size: 15Gi
   resources: {}


### PR DESCRIPTION
This PR changes how the `customize_fusion_values.sh` file determines the number of zookeeper replicas to run. Previously it used the same number of zookeeper nodes as `solr` nodes which caused problems if running with 2 solr nodes. It now:
  - Uses a single zookeeper node if the number of `solr` nodes < 3
  - Uses 3 zookeeper nodes otherwise, even with large fusion deployments we probably don't need more than 3 zookeepers running.