### PR TITLE
Consolidate scripts

### DIFF
--- a/monitoring/grafana/dashboard_indexing_metrics.json
+++ b/monitoring/grafana/dashboard_indexing_metrics.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 2,
-  "iteration": 1578596818436,
+  "iteration": 1578938805142,
   "links": [],
   "panels": [
     {
@@ -286,13 +286,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 12,
         "y": 8
       },
       "hiddenSeries": false,
-      "id": 5,
+      "id": 14,
       "legend": {
         "avg": false,
         "current": false,
@@ -318,101 +318,20 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by(pipelineId, le)(histogram_quantile(0.50, rate(indexing_docs_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "expr": "histogram_quantile(0.75, sum by(pipelineId,stageType,stageId,le)(rate(indexing_stage_process_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "legendFormat": "{{pipelineId}}({{stageType}}) {{stageId}}",
           "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Solr Indexing Time (p50)",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": null,
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "hiddenSeries": false,
-      "id": 2,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "dataLinks": []
-      },
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum by(pipelineId, le)(histogram_quantile(0.99, rate(indexing_docs_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
-          "refId": "A"
+          "expr": "",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Solr Indexing Time (p99)",
+      "title": "p75 Stage Execution Times",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -428,7 +347,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -461,7 +380,276 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 25
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by(pipelineId,stageType,stageId,le)(rate(indexing_stage_process_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "legendFormat": "{{pipelineId}}({{stageType}}) {{stageId}}",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "p50 Stage Execution Times",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by(pipelineId,stageType,stageId,le)(rate(indexing_stage_process_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "legendFormat": "{{pipelineId}}({{stageType}}) {{stageId}}",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "p99 Stage Execution Times",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by(pipelineId,stageType,stageId,le)(rate(indexing_stage_process_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "legendFormat": "{{pipelineId}}({{stageType}}) {{stageId}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "p95 Stage Execution Times",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
       },
       "hiddenSeries": false,
       "id": 4,
@@ -534,6 +722,350 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by(pipelineId, le)(rate(indexing_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Solr Indexing Time (p99)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by(pipelineId, le)(rate(indexing_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Solr Indexing Time (p50)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by(pipelineId, le)(rate(indexing_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Solr Indexing Time (p95)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.75, sum by(pipelineId, le)(rate(indexing_solr_index_time_secs_bucket{kubernetes_namespace=~\"$namespace\",pipelineId=~\"$pipeline\"}[1m])))",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Solr Indexing Time (p75)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": false,
@@ -545,7 +1077,6 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "default",
           "value": "default"
         },
@@ -576,14 +1107,14 @@
           "value": "$__all"
         },
         "datasource": "Prometheus",
-        "definition": "label_values(indexing_pipeline_outcome_total{kubernetes_namespace=~\"$namespace\",pipelineId=~\".+\"},pipelineId)",
+        "definition": "label_values(indexing_stage_process_time_secs_sum{kubernetes_namespace=~\"$namespace\",pipelineId=~\".+\"},pipelineId)",
         "hide": 0,
         "includeAll": true,
         "label": "Pipeline Id",
         "multi": true,
         "name": "pipeline",
         "options": [],
-        "query": "label_values(indexing_pipeline_outcome_total{kubernetes_namespace=~\"$namespace\",pipelineId=~\".+\"},pipelineId)",
+        "query": "label_values(indexing_stage_process_time_secs_sum{kubernetes_namespace=~\"$namespace\",pipelineId=~\".+\"},pipelineId)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -597,8 +1128,8 @@
     ]
   },
   "time": {
-    "from": "now-6h",
-    "to": "now"
+    "from": "2020-01-13T15:42:42.955Z",
+    "to": "2020-01-13T16:21:04.594Z"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -617,5 +1148,5 @@
   "timezone": "",
   "title": "Indexing Service Metrics",
   "uid": "RvRcaixWk",
-  "version": 4
+  "version": 3
 }

--- a/policy.json
+++ b/policy.json
@@ -7,21 +7,25 @@
   ],
   "set-policy": {
     "analytics": [
-      {"node": "#ANY", "shard": "#EACH", "replica":"<3", "strict": false},
-      {"replica":"#EQUAL", "shard":"#EACH", "sysprop.solr_zone":"#EACH", "strict": false},
-      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH", "strict": false},
+      {"replica" : "<3", "node":"#ANY"},
+      {"node": "#ANY", "shard": "#EACH", "replica":"<3"},
+      {"replica":"#EQUAL", "shard":"#EACH", "sysprop.solr_zone":"#EACH","strict": false},
+      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH","strict": false},
       {"replica": "#ALL", "sysprop.fusion_node_type": "analytics"}
     ],
     "search": [
+      {"replica" : "<2", "node":"#ANY"},
       {"node": "#ANY", "shard": "#EACH", "replica":"<2"},
+      {"replica": "#ALL", "type": "TLOG", "nodeset":{"sysprop.fusion_node_type": "analytics"}},
+      {"replica": "#ALL", "type": "PULL", "nodeset":{"sysprop.fusion_node_type": "search"}},
+      {"replica": "#ALL", "type": "NRT", "nodeset":{"sysprop.fusion_node_type": "search"}},
       {"replica":"#EQUAL", "shard":"#EACH", "sysprop.solr_zone":"#EACH", "strict": false},
-      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH", "strict": false},
-      {"replica": "#ALL", "sysprop.fusion_node_type": "search"}
+      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH", "strict": false}
     ],
     "system": [
-      {"node": "#ANY", "shard": "#EACH", "replica":"<3", "strict": false},
-      {"replica":"#EQUAL", "shard":"#EACH", "sysprop.solr_zone":"#EACH", "strict": false},
-      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH", "strict": false},
+      {"node": "#ANY", "shard": "#EACH", "replica":"<3"},
+      {"replica":"#EQUAL", "shard":"#EACH", "sysprop.solr_zone":"#EACH","strict": false},
+      {"replica": "#EQUAL", "sysprop.solr_zone": "#EACH","strict": false},
       {"replica": "#ALL", "sysprop.fusion_node_type": "system"}
     ]
   }

--- a/setup_f5_gke.sh
+++ b/setup_f5_gke.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
 INSTANCE_TYPE="n1-standard-4"
 CHART_VERSION="5.1.0"
 GKE_MASTER_VERSION="-"
@@ -15,7 +17,6 @@ GCS_BUCKET=
 CREATE_MODE=
 PURGE=0
 FORCE=0
-CUSTOM_MY_VALUES=()
 MY_VALUES=()
 ML_MODEL_STORE="fusion"
 DRY_RUN=""
@@ -175,7 +176,7 @@ if [ $# -gt 0 ]; then
               print_usage "$SCRIPT_CMD" "Missing value for the --values parameter!"
               exit 1
             fi
-            CUSTOM_MY_VALUES+=("$2")
+            MY_VALUES+=("$2")
             shift 2
         ;;
         --create)
@@ -375,6 +376,12 @@ fi
 gcloud container clusters get-credentials $CLUSTER_NAME
 current=$(kubectl config current-context)
 
+# Pass in custom values
+VALUES_STRING=""
+for v in "${MY_VALUES[@]}"; do
+  VALUES_STRING="${VALUES_STRING} --values ${v}"
+done
+
 INGRESS_VALUES=""
 if [ "${TLS_ENABLED}" == "1" ]; then
 
@@ -398,7 +405,7 @@ spec:
 EOF
 
   TLS_VALUES="tls-values.yaml"
-  INGRESS_VALUES="${INGRESS_VALUES} --values tls-values.yaml"
+  INGRESS_VALUES="${INGRESS_VALUES} --values tls-values.yaml --tls"
   tee "${TLS_VALUES}" << END
 api-gateway:
   service:
@@ -416,48 +423,13 @@ api-gateway:
 END
 fi
 
-DEFAULT_MY_VALUES="gke_${CLUSTER_NAME}_${RELEASE}_fusion_values.yaml"
-
-if [ ! -z "${CUSTOM_MY_VALUES[*]}" ]; then
-  MY_VALUES=(${CUSTOM_MY_VALUES[@]})
-fi
-
-VALUES_STRING=""
-if [ "${UPGRADE}" == "1" ] && [ -z "$MY_VALUES" ] && [ -f "${DEFAULT_MY_VALUES}" ]; then
-  MY_VALUES=( ${DEFAULT_MY_VALUES} )
-fi
-
-for v in "${MY_VALUES[@]}"; do
-  if [ ! -f "${v}" ]; then
-    echo -e "\nWARNING: Custom values file ${v} not found!\nYou need to provide the same custom values you provided when creating the cluster in order to upgrade.\n"
-    exit 1
-  fi
-  VALUES_STRING="${VALUES_STRING} --values ${v}"
-done
-
-if [ ! -z "${INGRESS_VALUES}" ]; then
-  # since we're passing INGRESS_VALUES to the setup_f5_k8s script,
-  # we might need to create the default from the template too
-  if [ -z "${VALUES_STRING}" ] && [ "${UPGRADE}" != "1" ] && [ ! -f "${DEFAULT_MY_VALUES}" ]; then
-
-    PROMETHEUS_ON=true
-    if [ "${PROMETHEUS}" == "none" ]; then
-      PROMETHEUS_ON=false
-    fi
-
-    source ./customize_fusion_values.sh $DEFAULT_MY_VALUES -c $CLUSTER_NAME -n $NAMESPACE -r $RELEASE --provider "gke" --prometheus $PROMETHEUS_ON \
-      --num-solr $SOLR_REPLICAS --solr-disk-gb $SOLR_DISK_GB --node-pool "${NODE_POOL}"
-    VALUES_STRING="--values ${DEFAULT_MY_VALUES}"
-  fi
-
-  VALUES_STRING="${VALUES_STRING} ${INGRESS_VALUES}"
-fi
 
 # Invoke the generic K8s setup script to complete the install/upgrade
 INGRESS_ARG=""
 if [ ! -z "${INGRESS_HOSTNAME}" ]; then
-  INGRESS_ARG=" --ingress ${INGRESS_HOSTNAME}"
+  INGRESS_ARG=" --ingress ${INGRESS_HOSTNAME} ${INGRESS_VALUES}"
 fi
+
 
 UPGRADE_ARGS=""
 if [ "${UPGRADE}" == "1" ]; then
@@ -479,7 +451,7 @@ fi
 
 # for debug only
 #echo -e "Calling setup_f5_k8s.sh with: ${VALUES_STRING}${INGRESS_ARG}${UPGRADE_ARGS}"
-source ./setup_f5_k8s.sh -c $CLUSTER_NAME -r "${RELEASE}" --provider "gke" -n "${NAMESPACE}" --node-pool "${NODE_POOL}" \
-  --version ${CHART_VERSION} --prometheus ${PROMETHEUS} ${VALUES_STRING}${INGRESS_ARG}${UPGRADE_ARGS}
+( ${SCRIPT_DIR}/setup_f5_k8s.sh -c $CLUSTER_NAME -r "${RELEASE}" --provider "gke" -n "${NAMESPACE}" --node-pool "${NODE_POOL}" \
+  --version ${CHART_VERSION} --prometheus ${PROMETHEUS} ${VALUES_STRING}${INGRESS_ARG}${UPGRADE_ARGS} )
 setup_result=$?
 exit $setup_result

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -414,6 +414,10 @@ done
 
 # If we are not upgrading then generate the values files and upgrade script
 if [ "$UPGRADE" != "1" ]; then
+  if [ -f "${UPGRADE_SCRIPT}" ]; then
+    echo "There is already an upgrade script ${UPGRADE_SCRIPT} present, please use a new release name or upgrade your current release"
+    exit 1
+  fi
   if [ ! -f "${DEFAULT_MY_VALUES}" ]; then
 
     PROMETHEUS_ON=true
@@ -450,7 +454,7 @@ set -e
 ( "${SCRIPT_DIR}/${UPGRADE_SCRIPT}" "${DRY_RUN}" )
 set +e
 
-if [ ! -z "${INGRESS_HOSTNAME}"]; then
+if [ ! -z "${INGRESS_HOSTNAME}" ]; then
   ingress_setup
 else
   proxy_url

--- a/setup_f5_k8s.sh
+++ b/setup_f5_k8s.sh
@@ -2,10 +2,12 @@
 
 # Platform agnostic script used by the other setup_f5_*.sh scripts to perform general K8s and Helm commands to install Fusion.
 # This script assumes kubectl is pointing to the right cluster and that the user is already authenticated.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 CHART_VERSION="5.1.0"
 PROVIDER="k8s"
 INGRESS_HOSTNAME=""
+TLS_ENABLED="0"
 PROMETHEUS="install"
 SCRIPT_CMD="$0"
 CLUSTER_NAME=
@@ -17,7 +19,8 @@ CUSTOM_MY_VALUES=()
 MY_VALUES=()
 DRY_RUN=""
 SOLR_DISK_GB=50
-NODE_POOL=""
+SOLR_REPLICAS=1
+NODE_POOL="{}"
 
 function print_usage() {
   CMD="$1"
@@ -29,24 +32,27 @@ function print_usage() {
 
   echo -e "\nUse this script to install Fusion 5 on an existing Kubernetes cluster"
   echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
-  echo -e "  -c            Name of the K8s cluster (required)\n"
-  echo -e "  -r            Helm release name for installing Fusion 5, defaults to 'f5'\n"
-  echo -e "  -n            Kubernetes namespace to install Fusion 5 into, defaults to 'default'\n"
-  echo -e "  --provider    Lowercase label for your K8s platform provider, e.g. eks, aks, gke; defaults to 'k8s'\n"
-  echo -e "  --node-pool   Node pool label to assign pods to specific nodes, this option is only useful for existing clusters"
-  echo -e "                where you defined a custom node pool, wrap the arg in double-quotes\n"
-  echo -e "  --ingress     Ingress hostname\n"
-  echo -e "  --prometheus  Enable Prometheus and Grafana for monitoring Fusion services, pass one of: install, provided, none;"
-  echo -e "                defaults to 'install' which installs Prometheus and Grafana from the stable Helm repo,"
-  echo -e "                'provided' enables pod annotations on Fusion services to work with Prometheus but does not install anything\n"
-  echo -e "  --version     Fusion Helm Chart version; defaults to the latest release from Lucidworks, such as ${CHART_VERSION}\n"
-  echo -e "  --values      Custom values file containing config overrides; defaults to gke_<cluster>_<namespace>_fusion_values.yaml"
-  echo -e "                (can be specified multiple times to add additional yaml files, see example-values/*.yaml)\n"
-  echo -e "  --upgrade     Perform a Helm upgrade on an existing Fusion installation\n"
-  echo -e "  --dry-run     Perform a dry-run of the upgrade to see what would change\n"
-  echo -e "  --purge       Uninstall and purge all Fusion objects from the specified namespace and cluster."
-  echo -e "                Be careful! This operation cannot be undone.\n"
-  echo -e "  --force       Force upgrade or purge a deployment if your account is not the value 'owner' label on the namespace\n"
+  echo -e "  -c                Name of the K8s cluster (required)\n"
+  echo -e "  -r                Helm release name for installing Fusion 5, defaults to 'f5'\n"
+  echo -e "  -n                Kubernetes namespace to install Fusion 5 into, defaults to 'default'\n"
+  echo -e "  --provider        Lowercase label for your K8s platform provider, e.g. eks, aks, gke; defaults to 'k8s'\n"
+  echo -e "  --node-pool       Node pool label to assign pods to specific nodes, this option is only useful for existing clusters"
+  echo -e "                    where you defined a custom node pool, wrap the arg in double-quotes\n"
+  echo -e "  --ingress         Ingress hostname\n"
+  echo -e "  --tls             Whether tls on the ingress\n"
+  echo -e "  --prometheus      Enable Prometheus and Grafana for monitoring Fusion services, pass one of: install, provided, none;"
+  echo -e "                    defaults to 'install' which installs Prometheus and Grafana from the stable Helm repo,"
+  echo -e "                    'provided' enables pod annotations on Fusion services to work with Prometheus but does not install anything\n"
+  echo -e "  --version         Fusion Helm Chart version; defaults to the latest release from Lucidworks, such as ${CHART_VERSION}\n"
+  echo -e "  --values          Custom values file containing config overrides in addition to the default gke_<cluster>_<namespace>_fusion_values.yaml"
+  echo -e "                    (can be specified multiple times to add additional yaml files, see example-values/*.yaml)\n"
+  echo -e "  --upgrade         Perform a Helm upgrade on an existing Fusion installation\n"
+  echo -e "  --dry-run         Perform a dry-run of the upgrade to see what would change\n"
+  echo -e "  --purge           Uninstall and purge all Fusion objects from the specified namespace and cluster."
+  echo -e "                    Be careful! This operation cannot be undone.\n"
+  echo -e "  --force           Force upgrade or purge a deployment if your account is not the value 'owner' label on the namespace\n"
+  echo -e "  --num-solr        Number of Solr pods to deploy, defaults to 1\n"
+  echo -e "  --solr-disk-gb    Size (in gigabytes) of the Solr persistent volume claim, defaults to 50\n"
 }
 
 if [ $# -gt 0 ]; then
@@ -92,6 +98,10 @@ if [ $# -gt 0 ]; then
             INGRESS_HOSTNAME="$2"
             shift 2
         ;;
+        --tls)
+            TLS_ENABLED=1
+            shift 1
+        ;;
         --prometheus)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_usage "$SCRIPT_CMD" "Missing value for the --prometheus parameter!"
@@ -100,6 +110,23 @@ if [ $# -gt 0 ]; then
             PROMETHEUS="$2"
             shift 2
         ;;
+        --num-solr)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the --num-solr parameter!"
+              exit 1
+            fi
+            SOLR_REPLICAS=$2
+            shift 2
+        ;;
+        --solr-disk-gb)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the --solr-disk-gb parameter!"
+              exit 1
+            fi
+            SOLR_DISK_GB=$2
+            shift 2
+        ;;
+
         --node-pool)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_usage "$SCRIPT_CMD" "Missing value for the --node-pool parameter!"
@@ -160,6 +187,7 @@ if [ $# -gt 0 ]; then
   done
 fi
 
+# Sanity check we have the required variables
 if [ "$CLUSTER_NAME" == "" ]; then
   print_usage "$SCRIPT_CMD" "Please provide the Kubernetes cluster name using: -c <cluster>"
   exit 1
@@ -185,8 +213,13 @@ if [[ $RELEASE =~ [^$valid] ]]; then
   exit 1
 fi
 
+# The default values file that will be created for the cluster
 DEFAULT_MY_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_fusion_values.yaml"
 
+# The name of the upgrade script that will be created to upgrade fusion
+UPGRADE_SCRIPT="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_upgrade_fusion.sh"
+
+# Check our prerequisites are in place
 hash kubectl
 has_prereq=$?
 if [ $has_prereq == 1 ]; then
@@ -201,9 +234,22 @@ if [ $has_prereq == 1 ]; then
   exit 1
 fi
 
+# Log our current kube context for the user
 current=$(kubectl config current-context)
-echo -e "\nUsing kubeconfig: $current\n"
+echo -e "Using kubeconfig: $current"
 
+# Setup our owner label so we can check ownership of namespaces
+if [ "$PROVIDER" == "gke" ]; then
+  who_am_i=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
+else
+  who_am_i=""
+fi
+OWNER_LABEL="${who_am_i//@/-}"
+
+echo -e "\nCreated namespace ${NAMESPACE} with owner label ${OWNER_LABEL}\n"
+
+# Determine if we have helm v3
+# TODO drop support for helm v2
 is_helm_v3=$(helm version --short | grep v3)
 
 if [ "${is_helm_v3}" == "" ]; then
@@ -221,11 +267,11 @@ else
   echo -e "Using Helm v3 ($is_helm_v3)"
 fi
 
+# If we are upgrading
 if [ "${UPGRADE}" == "1" ]; then
-
-  kubectl get namespace "${NAMESPACE}"
-  namespace_exists=$?
-  if [ "$namespace_exists" != "0" ]; then
+  # Make sure the namespace exists
+  if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
+    echo -e "\nNamespace ${NAMESPACE} not found, if this is a new cluster please run an install first"
     exit 1
   fi
 
@@ -233,14 +279,14 @@ if [ "${UPGRADE}" == "1" ]; then
   # accidentally upgrade a release from someone elses namespace
   namespace_owner=$(kubectl get namespace "${NAMESPACE}" -o 'jsonpath={.metadata.labels.owner}')
   if [ "${namespace_owner}" != "${OWNER_LABEL}" ] && [ "${FORCE}" != "1" ]; then
-    echo -e "Namespace "${NAMESPACE}" is owned by: ${namespace_owner}, by we are: "${OWNER_LABEL}" please provide the --force parameter if you are sure you wish to upgrade this namespace"
+    echo -e "Namespace ${NAMESPACE} is owned by: ${namespace_owner}, by we are: ${OWNER_LABEL} please provide the --force parameter if you are sure you wish to upgrade this namespace"
     exit 1
   fi
 elif [ "$PURGE" == "1" ]; then
-
   kubectl get namespace "${NAMESPACE}"
   namespace_exists=$?
   if [ "$namespace_exists" != "0" ]; then
+    echo -e "\nNamespace ${NAMESPACE} not found so assuming ${RELEASE_NAME} has already been purged"
     exit 1
   fi
 
@@ -248,7 +294,7 @@ elif [ "$PURGE" == "1" ]; then
   # accidentally purge someone elses release
   namespace_owner=$(kubectl get namespace "${NAMESPACE}" -o 'jsonpath={.metadata.labels.owner}')
   if [ "${namespace_owner}" != "${OWNER_LABEL}" ] && [ "${FORCE}" != "1" ]; then
-    echo -e "Namespace "${NAMESPACE}" is owned by: ${namespace_owner}, by we are: "${OWNER_LABEL}" please provide the --force parameter if you are sure you wish to purge this namespace"
+    echo -e "Namespace ${NAMESPACE} is owned by: ${namespace_owner}, by we are: ${OWNER_LABEL} please provide the --force parameter if you are sure you wish to purge this namespace"
     exit 1
   fi
 
@@ -257,21 +303,21 @@ elif [ "$PURGE" == "1" ]; then
   if [ "$confirm" == "" ] || [ "$confirm" == "Y" ] || [ "$confirm" == "y" ]; then
 
     if [ "$is_helm_v3" != "" ]; then
-      helm delete ${RELEASE} --namespace ${NAMESPACE}
-      helm delete ${RELEASE}-monitoring --namespace ${NAMESPACE}
-      helm delete ${RELEASE}-prom --namespace ${NAMESPACE}
-      helm delete ${RELEASE}-graf --namespace ${NAMESPACE}
+      helm delete "${RELEASE}" --namespace "${NAMESPACE}"
+      helm delete "${RELEASE}-monitoring" --namespace "${NAMESPACE}"
+      helm delete "${RELEASE}-prom" --namespace "${NAMESPACE}"
+      helm delete "${RELEASE}-graf" --namespace "${NAMESPACE}"
     else
-      helm del --purge ${RELEASE}
+      helm del --purge "${RELEASE}"
     fi
     kubectl delete deployments -l app.kubernetes.io/part-of=fusion --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
-    kubectl delete job ${RELEASE}-api-gateway --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=1s
+    kubectl delete job "${RELEASE}-api-gateway" --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=1s
     kubectl delete svc -l app.kubernetes.io/part-of=fusion --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=2s
     kubectl delete pvc -l app.kubernetes.io/part-of=fusion --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
-    kubectl delete pvc -l release=${RELEASE} --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
-    kubectl delete pvc -l app.kubernetes.io/instance=${RELEASE} --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
+    kubectl delete pvc -l "release=${RELEASE}" --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
+    kubectl delete pvc -l "app.kubernetes.io/instance=${RELEASE}" --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
     kubectl delete pvc -l app=prometheus --namespace "${NAMESPACE}" --grace-period=0 --force --timeout=5s
-    kubectl delete serviceaccount --namespace "${NAMESPACE}" ${RELEASE}-api-gateway-jks-create
+    kubectl delete serviceaccount --namespace "${NAMESPACE}" "${RELEASE}-api-gateway-jks-create"
     if [ "${NAMESPACE}" != "default" ] && [ "${NAMESPACE}" != "kube-public" ] && [ "${NAMESPACE}" != "kube-system" ]; then
       kubectl delete namespace "${NAMESPACE}" --grace-period=0 --force --timeout=10s
     fi
@@ -302,14 +348,15 @@ else
   # We should be good to install now
 fi
 
+# report_ns logs a message to the user informing them how to change the default namespace
 function report_ns() {
   if [ "${NAMESPACE}" != "default" ]; then
     echo -e "\nNote: Change the default namespace for kubectl to ${NAMESPACE} by doing:\n    kubectl config set-context --current --namespace=${NAMESPACE}\n"
   fi
 }
 
+# proxy_url prints how to access the proxy via a LoadBalancer service
 function proxy_url() {
-
   if [ "${PROVIDER}" == "eks" ]; then
     export PROXY_HOST=$(kubectl --namespace "${NAMESPACE}" get service proxy -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
   else
@@ -329,9 +376,8 @@ function proxy_url() {
   fi
 }
 
+# ingress_setup informs the user how to finish setting up the DNS records for their ingress with hostname
 function ingress_setup() {
-  # Patch yaml for now, until fix gets into helm charts
-  kubectl patch --namespace "${NAMESPACE}" ingress "${RELEASE}-api-gateway" -p "{\"spec\":{\"rules\":[{\"host\": \"${INGRESS_HOSTNAME}\", \"http\":{\"paths\":[{\"backend\": {\"serviceName\": \"proxy\", \"servicePort\": 6764}, \"path\": \"/*\"}]}}]}}"
   echo -ne "\nWaiting for the Loadbalancer IP to be assigned"
   loops=24
   while (( loops > 0 )); do
@@ -346,107 +392,14 @@ function ingress_setup() {
   done
   echo -e "\n\nFusion 5 Gateway service exposed at: ${INGRESS_HOSTNAME}\n"
   echo -e "Please ensure that the public DNS record for ${INGRESS_HOSTNAME} is updated to point to ${INGRESS_IP}"
+  if [ "$TLS_ENABLED" == "1" ]; then
   echo -e "An SSL certificate will be automatically generated once the public DNS record has been updated,\nthis may take up to an hour after DNS has updated to be issued.\nYou can use kubectl get managedcertificates -o yaml to check the status of the certificate issue process."
-  echo -e "Add the contents of tls-values.yaml to ${DEFAULT_MY_VALUES} under the api-gateway section."
+  fi
   report_ns
 }
 
-lw_helm_repo=lucidworks
-
-if ! helm repo list | grep -q "https://charts.lucidworks.com"; then
-  echo -e "\nAdding the Lucidworks chart repo to helm repo list"
-  helm repo add ${lw_helm_repo} https://charts.lucidworks.com
-fi
-
-if ! helm repo list | grep -q "https://kubernetes-charts.storage.googleapis.com"; then
-  echo -e "\nAdding the stable chart repo to helm repo list"
-  helm repo add stable https://kubernetes-charts.storage.googleapis.com
-fi
-
-# If no custom values are passed, and we are not upgrading, then supply a default values yaml
-if [ -z $CUSTOM_MY_VALUES ] && [ "$UPGRADE" != "1" ]; then
-  if [ ! -f "${DEFAULT_MY_VALUES}" ]; then
-
-    CREATED_MY_VALUES=1
-
-    PROMETHEUS_ON=true
-    if [ "${PROMETHEUS}" == "none" ]; then
-      PROMETHEUS_ON=false
-    fi
-
-    if [ "${NODE_POOL}" == "" ]; then
-      NODE_POOL="{}"
-    fi
-
-    source ./customize_fusion_values.sh $DEFAULT_MY_VALUES -c $CLUSTER_NAME -n $NAMESPACE -r $RELEASE --provider ${PROVIDER} --prometheus $PROMETHEUS_ON \
-      --num-solr $SOLR_REPLICAS --solr-disk-gb $SOLR_DISK_GB --node-pool "${NODE_POOL}"
-  else
-    echo -e "\nValues file $DEFAULT_MY_VALUES already exists.\n"
-  fi
-  MY_VALUES=( ${DEFAULT_MY_VALUES} )
-fi
-
 if [ ! -z "${CUSTOM_MY_VALUES[*]}" ]; then
   MY_VALUES=(${CUSTOM_MY_VALUES[@]})
-fi
-
-# if we're installing, then wait up to 60s to see the metrics server online, which seems to help make installs more robust on new clusters
-metrics_deployment=$(kubectl get deployment -n kube-system | grep metrics-server | cut -d ' ' -f1 -)
-kubectl rollout status deployment/${metrics_deployment} --timeout=60s --namespace "kube-system"
-echo ""
-
-if ! kubectl get namespace "${NAMESPACE}" > /dev/null; then
-  if [ "${UPGRADE}" != "1" ]; then
-    kubectl create namespace "${NAMESPACE}"
-    kubectl label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"
-  fi
-fi
-
-# Make sure we have all the updated charts
-helm repo update
-
-# Don't mess with upgrading the Prom / Grafana charts during upgrade
-# just let the user do that manually with Helm as needed
-if [ "$UPGRADE" != "1" ] && [ "${PROMETHEUS}" != "none" ]; then
-
-  if [ "${NODE_POOL}" == "" ]; then
-    NODE_POOL="{}"
-  fi
-
-
-  MONITORING_VALUES="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_monitoring_values.yaml"
-  if [ ! -f "${MONITORING_VALUES}" ]; then
-    cp example-values/monitoring-values.yaml "${MONITORING_VALUES}"
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
-      sed -i -e "s|{NODE_POOL}|${NODE_POOL}|g" "${MONITORING_VALUES}"
-      sed -i -e "s|{NAMESPACE}|${NAMESPACE}|g" "${MONITORING_VALUES}"
-    else
-      sed -i '' -e "s|{NODE_POOL}|${NODE_POOL}|g" "${MONITORING_VALUES}"
-      sed -i '' -e "s|{NAMESPACE}|${NAMESPACE}|g" "${MONITORING_VALUES}"
-    fi
-    echo -e "\nCreated Monitoring custom values yaml: ${MONITORING_VALUES}. Keep this file handy as you'll need it to customize your Monitoring installation.\n"
-  fi
-
-  if [ "${PROMETHEUS}" == "install" ]; then
-    echo -e "\nInstalling Prometheus and Grafana for monitoring Fusion metrics ... this can take a few minutes.\n"
-
-    helm dep up ./monitoring/helm/fusion-monitoring
-
-    helm install ${RELEASE}-monitoring ./monitoring/helm/fusion-monitoring --namespace "${NAMESPACE}" -f "${MONITORING_VALUES}" \
-      --set-file grafana.dashboards.default.dashboard_gateway_metrics.json=monitoring/grafana/dashboard_gateway_metrics.json \
-      --set-file grafana.dashboards.default.dashboard_indexing_metrics.json=monitoring/grafana/dashboard_indexing_metrics.json \
-      --set-file grafana.dashboards.default.dashboard_jvm_metrics.json=monitoring/grafana/dashboard_jvm_metrics.json \
-      --set-file grafana.dashboards.default.dashboard_query_pipeline.json=monitoring/grafana/dashboard_query_pipeline.json \
-      --set-file grafana.dashboards.default.dashboard_solr_core.json=monitoring/grafana/dashboard_solr_core.json \
-      --set-file grafana.dashboards.default.dashboard_solr_node.json=monitoring/grafana/dashboard_solr_node.json \
-      --set-file grafana.dashboards.default.dashboard_solr_system.json=monitoring/grafana/dashboard_solr_system.json \
-      --set-file grafana.dashboards.default.kube_metrics.json=monitoring/grafana/kube_metrics.json \
-      --set-file grafana.dashboards.default.kube_metrics.json=monitoring/grafana/pulsar_grafana_dashboard.json \
-      --wait --render-subchart-notes
-
-    echo -e "\n\nSuccessfully installed Prometheus and Grafana into the ${NAMESPACE} namespace.\n"
-  fi
-
 fi
 
 # build up a list of multiple --values args to pass to Helm
@@ -456,87 +409,49 @@ for v in "${MY_VALUES[@]}"; do
     echo -e "\nERROR: Custom values file ${v} not found! Please check your --values arg(s)\n"
     exit 1
   fi
-  VALUES_STRING="${VALUES_STRING} --values ${v}"
+  VALUES_STRING="${VALUES_STRING} --additional-values ${v}"
 done
 
-if [ "$UPGRADE" == "1" ]; then
+# If we are not upgrading then generate the values files and upgrade script
+if [ "$UPGRADE" != "1" ]; then
+  if [ ! -f "${DEFAULT_MY_VALUES}" ]; then
 
-  if [ "${VALUES_STRING}" == "" ]; then
-    # no values passed to upgrade, but if the default exists, we'll just use it or error out
-    if [ -f "${DEFAULT_MY_VALUES}" ]; then
-      VALUES_STRING="--values ${DEFAULT_MY_VALUES}"
-    else
-      echo -e "\nERROR: Missing one or more custom values yaml files for upgrade!\nAt a minimum, you must pass --values ${DEFAULT_MY_VALUES} to upgrade your cluster.\n"
-      exit 1
+    PROMETHEUS_ON=true
+    if [ "${PROMETHEUS}" == "none" ]; then
+      PROMETHEUS_ON=false
     fi
-  fi
 
-  if [ "${DRY_RUN}" == "" ]; then
-    echo -e "\nUpgrading the Fusion 5 release ${RELEASE} in namespace ${NAMESPACE} to version ${CHART_VERSION} with custom values from ${MY_VALUES[*]}"
+     ( "${SCRIPT_DIR}/customize_fusion_values.sh" "${DEFAULT_MY_VALUES}" -c "${CLUSTER_NAME}" -n "${NAMESPACE}" -r "${RELEASE}" --provider "${PROVIDER}" --prometheus "${PROMETHEUS_ON}" \
+      --num-solr "${SOLR_REPLICAS}" --solr-disk-gb "${SOLR_DISK_GB}" --node-pool "${NODE_POOL}" --with-resource-limits --output-script "${UPGRADE_SCRIPT}" ${VALUES_STRING} )
   else
-    echo -e "\nSimulating an update of the Fusion ${RELEASE} installation into the ${NAMESPACE} namespace with custom values from ${MY_VALUES[*]}"
+    echo -e "\nValues file $DEFAULT_MY_VALUES already exists, not regenerating.\n"
   fi
-
-  helm upgrade ${RELEASE} "${lw_helm_repo}/fusion" --namespace "${NAMESPACE}" ${VALUES_STRING} ${DRY_RUN} --version "${CHART_VERSION}"
-  upgrade_status=$?
-  if [ "${TLS_ENABLED}" == "1" ]; then
-    ingress_setup
-  else
-    proxy_url
-  fi
-  exit $upgrade_status
 fi
 
-echo -e "\nInstalling Fusion 5.0 Helm chart ${CHART_VERSION} into namespace ${NAMESPACE} with release tag: ${RELEASE} using custom values from ${MY_VALUES[*]}"
-echo -e "\nNOTE: If this will be a long-running cluster for production purposes, you should save the ${MY_VALUES[*]} file(s) in version control.\n"
+# Don't mess with upgrading the Prom / Grafana charts during upgrade
+# just let the user do that manually with Helm as needed
+if [ "$UPGRADE" != "1" ] && [ "${PROMETHEUS}" != "none" ]; then
+  if [ "${PROMETHEUS}" == "install" ]; then
+    ( "${SCRIPT_DIR}/install_prom.sh" -c "${CLUSTER_NAME}" -n "${NAMESPACE}" -r "${RELEASE}" --provider "${PROVIDER}" --node-pool "${NODE_POOL}" )
+  fi
+fi
+
+if [ "$UPGRADE" == "1" ]; then
+  if [ ! -f "${SCRIPT_DIR}/${UPGRADE_SCRIPT}" ]; then
+    echo -e "\nUpgrade script ${SCRIPT_DIR}/${UPGRADE_SCRIPT} not found, if this is a new cluster please run an install first"
+    exit 1
+  fi
+else
+  echo -e "\nInstalling Fusion 5.0 Helm chart ${CHART_VERSION} into namespace ${NAMESPACE} with release tag: ${RELEASE}}"
+fi
 
 # let's exit immediately if the helm install command fails
 set -e
-if [ "$is_helm_v3" != "" ]; then
-  if ! kubectl get namespace "${NAMESPACE}"; then
-    kubectl create namespace "${NAMESPACE}"
-  fi
-  # looks like Helm V3 doesn't like the -n parameter for the release name anymore
-  helm install "${RELEASE}" ${lw_helm_repo}/fusion --timeout=240s --namespace "${NAMESPACE}" ${VALUES_STRING} --version "${CHART_VERSION}"
-else
-  helm install ${lw_helm_repo}/fusion --timeout 240 --namespace "${NAMESPACE}" -n "${RELEASE}" ${VALUES_STRING} --version "${CHART_VERSION}"
-fi
+( "${SCRIPT_DIR}/${UPGRADE_SCRIPT}" "${DRY_RUN}" )
 set +e
 
-echo -e "\nWaiting up to 10 minutes to see the Fusion API Gateway deployment come online ...\n"
-kubectl rollout status deployment/${RELEASE}-api-gateway --timeout=600s --namespace "${NAMESPACE}"
-echo -e "\nWaiting up to 2 minutes to see the Fusion Admin deployment come online ...\n"
-kubectl rollout status deployment/${RELEASE}-fusion-admin --timeout=120s --namespace "${NAMESPACE}"
-
-echo -e "\nHelm releases:"
-helm ls --namespace "${NAMESPACE}"
-
-if [ "${TLS_ENABLED}" == "1" ]; then
+if [ ! -z "${INGRESS_HOSTNAME}"]; then
   ingress_setup
 else
   proxy_url
 fi
-kubectl config set-context --current --namespace=${NAMESPACE}
-
-UPGRADE_SCRIPT="${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_upgrade_fusion.sh"
-cp upgrade_fusion.sh.example $UPGRADE_SCRIPT
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  sed -i -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<RESOURCES_YAML>||g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<AFFINITY_YAML>||g" "$UPGRADE_SCRIPT"
-  sed -i -e "s|<REPLICAS_YAML>||g" "$UPGRADE_SCRIPT"
-else
-  sed -i '' -e "s|<PROVIDER>|${PROVIDER}|g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<CLUSTER>|${CLUSTER_NAME}|g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<RELEASE>|${RELEASE}|g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<NAMESPACE>|${NAMESPACE}|g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<CHART_VERSION>|${CHART_VERSION}|g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<RESOURCES_YAML>||g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<AFFINITY_YAML>||g" "$UPGRADE_SCRIPT"
-  sed -i '' -e "s|<REPLICAS_YAML>||g" "$UPGRADE_SCRIPT"
-fi
-echo -e "\nCreating $UPGRADE_SCRIPT for upgrading you Fusion cluster. Please keep this script along with your custom values yaml file(s) in version control.\n"

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -96,7 +96,7 @@ If you're running Prometheus and Grafana for monitoring the performance and heal
 +
 [source,bash]
 ----
-kubectl get secret --namespace "${NAMESPACE}" f5-graf-grafana \
+kubectl get secret --namespace "${NAMESPACE}" ${RELEASE}-monitoring-grafana \
   -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 ----
 
@@ -104,7 +104,7 @@ kubectl get secret --namespace "${NAMESPACE}" f5-graf-grafana \
 +
 [source,bash]
 ----
-kubectl expose deployment ${RELEASE}-graf-grafana --type=LoadBalancer --name=grafana
+kubectl expose deployment ${RELEASE}-monitoring-grafana --type=LoadBalancer --name=grafana --port=3000 --target-port=3000
 ----
 
 . Use `kubectl get services --namespace <namespace>` to verify that the load balancer is set up and its IP address.

--- a/update_commit_within_f5.sh
+++ b/update_commit_within_f5.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if [ -z $LW_K8S_GATEWAY ]; then
+  if [ -z $LW_K8S_GATEWAY_IP ]; then
+    echo -e "\nERROR: No LW_K8S_GATEWAY or LW_K8S_GATEWAY_IP defined!\n"
+    exit 1
+  fi
+
+  LW_K8S_GATEWAY="http://${LW_K8S_GATEWAY_IP}:6764"
+fi
+
+if [ -z $LW_K8S_CREDS ]; then
+  LW_K8S_CREDS="admin:password123"
+fi
+
+COLLECTION=$1
+if [ -z "$COLLECTION" ]; then
+  echo "ERROR: Pass the collection name!"
+  exit 1
+fi
+
+COMMIT_WITHIN="$2"
+if [ -z "$COMMIT_WITHIN" ]; then
+  COMMIT_WITHIN="-1"
+fi
+
+find="\"commitWithin\" : [[:digit:]]+"
+replace="\"commitWithin\" : $COMMIT_WITHIN"
+json_file="${COLLECTION}.json"
+
+curl -s -u $LW_K8S_CREDS "$LW_K8S_GATEWAY/api/collections/${COLLECTION}" > $json_file
+
+echo -e "\nCurrent properties for $COLLECTION:"
+cat $json_file
+
+sed -E -i '' "s/${find}/${replace}/" $json_file
+
+echo -e "\n\nUpdated to:"
+curl -u $LW_K8S_CREDS -XPUT "$LW_K8S_GATEWAY/api/collections/${COLLECTION}" -H "Content-type:application/json" -d @$json_file
+
+rm $json_file

--- a/update_policy.sh
+++ b/update_policy.sh
@@ -2,21 +2,3 @@
 SOLR=http://localhost:8983
 curl -XPOST "$SOLR/api/cluster/autoscaling" -H "Content-type:application/json" --data-binary @policy.json
 curl "$SOLR/api/cluster/autoscaling"
-
-exit 0
-
-APP=
-
-echo -e "\nCreating Analytics collection in the Analytics partition"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_signals&collection.configName=${APP}_signals&numShards=3&replicationFactor=2&policy=Analytics"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_query_rewrite_staging&collection.configName=${APP}_query_rewrite_staging&numShards=1&replicationFactor=2&policy=Analytics"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_job_reports&collection.configName=${APP}_job_reports&numShards=1&replicationFactor=2&policy=Analytics"
-
-sleep 3
-
-echo -e "\nCreating Search collections in the Search partition"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}&collection.configName=${APP}&numShards=1&replicationFactor=3&policy=search"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_signals_aggr&collection.configName=${APP}_signals_aggr&numShards=1&replicationFactor=3&policy=search"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_query_rewrite&collection.configName=${APP}_query_rewrite&numShards=1&replicationFactor=3&policy=search"
-curl "$SOLR/solr/admin/collections?action=CREATE&name=${APP}_user_prefs&collection.configName=${APP}_user_prefs&numShards=1&replicationFactor=2&policy=search"
-

--- a/upgrade_fusion.sh.example
+++ b/upgrade_fusion.sh.example
@@ -17,7 +17,6 @@ MY_VALUES=""
 # TODO: append more --values <file> args here as needed for your installation
 #MY_VALUES="${MY_VALUES} --values ${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_fusion_affinity.yaml"
 
-
 DRY_RUN=""
 DRY_RUN_REQUESTED="${1:-}"
 
@@ -61,7 +60,7 @@ kubectl rollout status deployment/${metrics_deployment} --timeout=60s --namespac
 echo ""
 
 echo -e "Upgrading the '$RELEASE' release (Fusion chart: $CHART_VERSION) in the '$NAMESPACE' namespace in the '$CLUSTER_NAME' cluster using values:\n    ${MY_VALUES//--values}"
-  echo -e "\nNOTE: If this will be a long-running cluster for production purposes, you should save the ${MY_VALUES//--values} file(s) in version control.\n"
+echo -e "\nNOTE: If this will be a long-running cluster for production purposes, you should save the following file(s) in version control:\n${MY_VALUES//--values}\n"
 
 helm upgrade ${DRY_RUN} ${RELEASE} "${lw_helm_repo}/fusion" --install --namespace "${NAMESPACE}" --version "${CHART_VERSION}" ${MY_VALUES}
 
@@ -76,3 +75,4 @@ if [ "$NAMESPACE" != "$current_ns" ]; then
 fi
 echo ""
 helm ls
+echo ""

--- a/upgrade_fusion.sh.example
+++ b/upgrade_fusion.sh.example
@@ -2,20 +2,28 @@
 
 # This script helps you keep track of the parameters needed to upgrade a Fusion cluster in Kubernetes
 # vs. having to remember all the --values parameters you need to pass
-
 PROVIDER=<PROVIDER>
 CLUSTER_NAME=<CLUSTER>
 RELEASE=<RELEASE>
 NAMESPACE=<NAMESPACE>
 CHART_VERSION=<CHART_VERSION>
 
-MY_VALUES="--values ${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_fusion_values.yaml"
+MY_VALUES=""
+<BASE_CUSTOM_VALUES>
 <RESOURCES_YAML>
 <AFFINITY_YAML>
 <REPLICAS_YAML>
-
+<ADDITIONAL_VALUES>
 # TODO: append more --values <file> args here as needed for your installation
 #MY_VALUES="${MY_VALUES} --values ${PROVIDER}_${CLUSTER_NAME}_${RELEASE}_fusion_affinity.yaml"
+
+
+DRY_RUN=""
+DRY_RUN_REQUESTED="${1:-}"
+
+if [ ! -z "${DRY_RUN_REQUESTED}" ]; then
+  DRY_RUN="--dry-run"
+fi
 
 current_context=$(kubectl config current-context | grep "$CLUSTER_NAME")
 if [ "${current_context}" == "" ]; then
@@ -37,14 +45,25 @@ if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
   echo -e "\nCreated namespace ${NAMESPACE} with owner label ${OWNER_LABEL}\n"
 fi
 
+# Make sure that the lucidworks chart repository is present and updated
+lw_helm_repo=lucidworks
+
+if ! helm repo list | grep -q "https://charts.lucidworks.com"; then
+  echo -e "\nAdding the Lucidworks chart repo to helm repo list"
+  helm repo add ${lw_helm_repo} https://charts.lucidworks.com
+fi
+
 helm repo update
 
+# Make sure that the metric server is running
 metrics_deployment=$(kubectl get deployment -n kube-system | grep metrics-server | cut -d ' ' -f1 -)
 kubectl rollout status deployment/${metrics_deployment} --timeout=60s --namespace "kube-system"
 echo ""
 
-echo -e "Upgrading the '$RELEASE' release (Fusion chart: $CHART_VERSION) in the '$NAMESPACE' namespace in the '$CLUSTER_NAME' cluster using values:\n    ${MY_VALUES}"
-helm upgrade ${RELEASE} "lucidworks/fusion" --install --namespace "${NAMESPACE}" --version "${CHART_VERSION}" ${MY_VALUES}
+echo -e "Upgrading the '$RELEASE' release (Fusion chart: $CHART_VERSION) in the '$NAMESPACE' namespace in the '$CLUSTER_NAME' cluster using values:\n    ${MY_VALUES//--values}"
+  echo -e "\nNOTE: If this will be a long-running cluster for production purposes, you should save the ${MY_VALUES//--values} file(s) in version control.\n"
+
+helm upgrade ${DRY_RUN} ${RELEASE} "${lw_helm_repo}/fusion" --install --namespace "${NAMESPACE}" --version "${CHART_VERSION}" ${MY_VALUES}
 
 current_ns=$(kubectl config view --minify --output 'jsonpath={..namespace}')
 if [ "$NAMESPACE" != "$current_ns" ]; then

--- a/upgrade_fusion.sh.example
+++ b/upgrade_fusion.sh.example
@@ -65,6 +65,11 @@ echo -e "Upgrading the '$RELEASE' release (Fusion chart: $CHART_VERSION) in the 
 
 helm upgrade ${DRY_RUN} ${RELEASE} "${lw_helm_repo}/fusion" --install --namespace "${NAMESPACE}" --version "${CHART_VERSION}" ${MY_VALUES}
 
+echo -e "\nWaiting up to 10 minutes to see the Fusion API Gateway deployment come online ...\n"
+kubectl rollout status deployment/${RELEASE}-api-gateway --timeout=600s --namespace "${NAMESPACE}"
+echo -e "\nWaiting up to 2 minutes to see the Fusion Admin deployment come online ...\n"
+kubectl rollout status deployment/${RELEASE}-fusion-admin --timeout=120s --namespace "${NAMESPACE}"
+
 current_ns=$(kubectl config view --minify --output 'jsonpath={..namespace}')
 if [ "$NAMESPACE" != "$current_ns" ]; then
   kubectl config set-context --current --namespace=${NAMESPACE}


### PR DESCRIPTION
This PR:
  - Changes the handling of installs so that now all installs of a cluster are done with the generated upgrade scripts. The `setup_f5_k8s.sh` script now calls this upgrade script and `install_prom.sh` to setup the clusters, and the cloud provider specific scripts create a cluster and then call the `setup_f5_k8s.sh` script.

More testing is required on the aks cluster setup before we merge this.