### PR TITLE
DOCS-2343 Spark History Server Updates

### DIFF
--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -575,7 +575,7 @@ While logs from the Spark driver and executor pods can be viewed using `kubectl 
 
 //tag::history-install[]
 
-Spark History Server can be installed via its Helm chart and a specifc `values.yaml` file to override the defaults:
+Spark History Server can be installed via its publicly-available Helm chart. To accomplish this, we must create a `values.yaml` file to configure it.
 ----
 helm install stable/spark-history-server --values values.yaml
 ----
@@ -600,7 +600,7 @@ service:
 
 nfs.enableExampleNFS: false
 ----
-The `service` key sets up the history server on an internal IP within your cluster but does not create an external LoadBalancer (which is the default setting in the Spark History Server Helm chart). This prevents the server from being exposed to outside access by default. We’ll look at how to access the history server shortly.
+Note that, by default, the Spark History Server Helm chart creates an external LoadBalancer, exposing it to outside access. This is usually undesirable. In the above, we prevent this via the `service` key - the history server will only be set up on an internal IP within your cluster and will not be exposed externally. Later, we will show how to properly access the history server.
 
 The `key` and `secret` fields provide the Spark History Server with the details of where it will find an account with access to the Google Cloud Storage bucket given in `logDirectory`. In the following example, we're going to set up a new service account that will be shared between the Spark History Server and the Spark driver/executors for both viewing and writing logs.
 
@@ -703,9 +703,9 @@ s3:
 
 ===== Configuring Spark
 
-After the History Server has been set up, then the config map for Fusion's job-launcher will need its `application.yaml` key will need to be updated with these Spark settings so the driver and executors know where to write out their logs.
+After starting the history server, we must update the config map for Fusion's job-launcher so it can write logs to the same location that Spark History Server is reading from.
 
-In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to a Google Cloud Storage bucket.
+In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to the same Google Cloud Storage bucket we configured the history server to read from.
 
 [source,bash]
 ----

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -597,10 +597,14 @@ gcs:
 service:
   type: ClusterIP
   port: 18080
+
+nfs.enableExampleNFS: false
 ----
 The `service` key sets up the history server on an internal IP within your cluster but does not create an external LoadBalancer (which is the default setting in the Spark History Server Helm chart). This prevents the server from being exposed to outside access by default. We’ll look at how to access the history server shortly.
 
 The `key` and `secret` fields provide the Spark History Server with the details of where it will find an account with access to the Google Cloud Storage bucket given in `logDirectory`. In the following example, we're going to set up a new service account that will be shared between the Spark History Server and the Spark driver/executors for both viewing and writing logs.
+
+The `nfs.enableExampleNFS` option turns off the NFS server that the History Server sets up by default, as we won't be needing it in our installation.
 
 [source,bash]
 ----

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -606,7 +606,7 @@ The `key` and `secret` fields provide the Spark History Server with the details 
 
 The `nfs.enableExampleNFS` option turns off the NFS server that the Spark History Server sets up by default, as we won't be needing it in our installation.
 
-In order to give the Spark History Server access to the Google Cloud Storage bucket where the logs will be kept, we use `gcloud`'s `create` to create a new service account, and then `keys create` to create a JSON keypair which we will shortly upload into our cluster as a Kubernetes secret.
+In order to give the Spark History Server access to the Google Cloud Storage bucket where the logs will be kept, we use `gcloud` to create a new service account, and then `keys create` to create a JSON keypair which we will shortly upload into our cluster as a Kubernetes secret.
 
 [source,bash]
 ----

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -568,7 +568,7 @@ This cron job is created automatically when the `job-launcher` microservice is i
 ==== Spark History Server
 
 //tag::history-intro[]
-While logs from the Spark driver and executor pods can be viewed using `kubectl logs [POD_NAME]`, executor pods are deleted at their end of their execution, and driver pods are deleted by Fusion on a default schedule of every hour. In order to store and view Spark logs in a more long-term fashion, you can install the Spark History Server into your Kubernetes cluster and configure Spark to write logs in a manner that will persist.
+While logs from the Spark driver and executor pods can be viewed using `kubectl logs [POD_NAME]`, executor pods are deleted at their end of their execution, and driver pods are deleted by Fusion on a default schedule of every hour. In order to store and view Spark logs in a more long-term fashion, you can install the https://spark.apache.org/docs/latest/monitoring.html[Spark History Server] into your Kubernetes cluster and configure Spark to write logs in a manner that will persist.
 //end::history-intro[]
 
 ===== Installing Spark History Server
@@ -577,7 +577,7 @@ While logs from the Spark driver and executor pods can be viewed using `kubectl 
 
 Spark History Server can be installed via its publicly-available Helm chart. To accomplish this, we must create a `values.yaml` file to configure it.
 ----
-helm install stable/spark-history-server --values values.yaml
+helm install [namespace]-spark-history-server stable/spark-history-server --values values.yaml
 ----
 
 //end::history-install[]
@@ -600,23 +600,29 @@ service:
 
 nfs.enableExampleNFS: false
 ----
-Note that, by default, the Spark History Server Helm chart creates an external LoadBalancer, exposing it to outside access. This is usually undesirable. In the above, we prevent this via the `service` key - the history server will only be set up on an internal IP within your cluster and will not be exposed externally. Later, we will show how to properly access the history server.
+Note that, by default, the Spark History Server Helm chart creates an external LoadBalancer, exposing it to outside access. This is usually undesirable. In the above, we prevent this via the `service` key - the Spark History Server will only be set up on an internal IP within your cluster and will not be exposed externally. Later, we will show how to properly access the Spark History Server.
 
 The `key` and `secret` fields provide the Spark History Server with the details of where it will find an account with access to the Google Cloud Storage bucket given in `logDirectory`. In the following example, we're going to set up a new service account that will be shared between the Spark History Server and the Spark driver/executors for both viewing and writing logs.
 
-The `nfs.enableExampleNFS` option turns off the NFS server that the History Server sets up by default, as we won't be needing it in our installation.
+The `nfs.enableExampleNFS` option turns off the NFS server that the Spark History Server sets up by default, as we won't be needing it in our installation.
+
+In order to give the Spark History Server access to the Google Cloud Storage bucket where the logs will be kept, we use `gcloud`'s `create` to create a new service account, and then `keys create` to create a JSON keypair which we will shortly upload into our cluster as a Kubernetes secret.
 
 [source,bash]
 ----
 $ export ACCOUNT_NAME=sparkhistory
 $ export GCP_PROJECT_ID=[PROJECT_ID]
 $ gcloud iam service-accounts create ${ACCOUNT_NAME} --display-name "${ACCOUNT_NAME}"
-$ gcloud iam service-accounts keys create "${ACCOUNT_NAME}.json" --iam-account "${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+$ gcloud iam service-accounts keys create "${ACCOUNT_NAME}.json" --iam-account "${
+ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+
+We then give our service account the `storage/admin` role, allowing it to perform create and view operations, and the final `gsutil` command applies our service account to our chosen bucket. If you have an existing service account you wish to use instead, you can skip the `create` command, though you will still need to create the JSON keypair and ensure that the existing account can read and write to the log bucket.
+
+[source,bash]
+----
 $ gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member "serviceAccount:${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" --role roles/storage.admin
 $ gsutil iam ch serviceAccount:${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com:objectAdmin gs://[BUCKET_NAME]
 ----
-
-First, we use `create` to create a new service account, and then `keys create` to create a JSON keypair which we will shortly upload into our cluster as a Kubernetes secret. We then give our service account the `storage/admin` role, allowing it to perform create and view operations, and the final `gsutil` command applies our service account to our chosen bucket. If you have an existing service account you wish to use instead, you can skip the `create` command, though you will still need to create the JSON keypair and ensure that the existing account can read and write to the log bucket.
 
 We now need to upload the JSON keypair into the cluster as a secret:
 
@@ -625,7 +631,7 @@ We now need to upload the JSON keypair into the cluster as a secret:
 kubectl -n [NAMESPACE] create secret generic history-secrets --from-file=sparkhistory.json
 ----
 
-With all this in place, the Spark History Server can now be installed with `helm install stable/spark-history-server --values values.yaml`.
+With all this in place, the Spark History Server can now be installed with `helm install [namespace]-spark-history-server stable/spark-history-server --values values.yaml`.
 
 ===== Other Configurations
 
@@ -703,13 +709,13 @@ s3:
 
 ===== Configuring Spark
 
-After starting the history server, we must update the config map for Fusion's job-launcher so it can write logs to the same location that Spark History Server is reading from.
+After starting the Spark History Server, we must update the config map for Fusion's job-launcher so it can write logs to the same location that Spark History Server is reading from.
 
-In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to the same Google Cloud Storage bucket we configured the history server to read from.
+In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to the same Google Cloud Storage bucket we configured the Spark History Server to read from.
 
 [source,bash]
 ----
-kubectl edit cm spark-history-job-launcher
+kubectl edit cm sparkhistory-job-launcher
 ----
 
 Update the `spark` key with these settings and then restart the `job-launcher` pod.
@@ -747,13 +753,13 @@ spark:
 
 //tag::history-access[]
 
-As we have set up the History Server to only set up a ClusterIP, we will need to port forward the server using `kubectl`:
+As we have set up the Spark History Server to only set up a ClusterIP, we will need to port forward the server using `kubectl`:
 ----
 kubectl get pods # to find the Spark History Server pod
 kubectl port-forward [POD_NAME] 18080:18080
 ----
 
-You can now access the Spark History Server at `\http://localhost:18080`.
+You can now access the Spark History Server at `\http://localhost:18080`. Run a Spark job and confirm that you can see the logs appear in the UI.
 
 //end::history-access[]
 

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -726,7 +726,7 @@ spark:
           service:
             account:
               json:
-                keyfile: /etc/secrets/[ACCOUNT_NAME].json]
+                keyfile: /etc/secrets/[ACCOUNT_NAME].json
   kubernetes:
     driver:
       secrets:

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -568,7 +568,7 @@ This cron job is created automatically when the `job-launcher` microservice is i
 ==== Spark History Server
 
 //tag::history-intro[]
-While logs from the Spark driver and executor pods can be viewed using `kubectl logs [POD_NAME]`, executor pods are deleted at their end of their execution, and driver pods are deleted by Fusion on a default schedule of every hour. In order to store and view Spark logs in a more long-term fashion, you can install the https://spark.apache.org/docs/latest/monitoring.html[Spark History Server] into your Kubernetes cluster and configure Spark to write logs in a manner that will persist.
+While logs from the Spark driver and executor pods can be viewed using `kubectl logs [POD_NAME]`, executor pods are deleted at their end of their execution, and driver pods are deleted by Fusion on a default schedule of every hour. In order to store and view Spark logs in a more long-term fashion, you can install the https://spark.apache.org/docs/latest/monitoring.html[Spark History Server^] into your Kubernetes cluster and configure Spark to write logs in a manner that will persist.
 //end::history-intro[]
 
 ===== Installing Spark History Server

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -598,7 +598,10 @@ service:
   type: ClusterIP
   port: 18080
 
-nfs.enableExampleNFS: false
+pvc:
+  enablePVC: false
+nfs:
+  enableExampleNFS: false
 ----
 Note that, by default, the Spark History Server Helm chart creates an external LoadBalancer, exposing it to outside access. This is usually undesirable. In the above, we prevent this via the `service` key - the Spark History Server will only be set up on an internal IP within your cluster and will not be exposed externally. Later, we will show how to properly access the Spark History Server.
 

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -715,14 +715,16 @@ s3:
 
 After starting the Spark History Server, we must update the config map for Fusion's job-launcher so it can write logs to the same location that Spark History Server is reading from.
 
-In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to the same Google Cloud Storage bucket we configured the Spark History Server to read from.
+In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to the same Google Cloud Storage bucket we configured the Spark History Server to read from. Before editing the config map, make a copy of the existing settings in case you need to revert the changes.
 
 [source,bash]
 ----
-kubectl edit cm sparkhistory-job-launcher
+kubectl get cm -n [NAMESPACE] sparkhistory-job-launcher -o yaml > sparkhistory-job-launcher.yaml
+
+kubectl edit cm -n [NAMESPACE] sparkhistory-job-launcher
 ----
 
-Update the `spark` key with these settings and then restart the `job-launcher` pod.
+Update the `spark` key with these settings and then delete the `job-launcher` pod. The new `job-launcher` pod will apply the new configuration to subsequent jobs.
 
 
 [source,yaml]
@@ -740,14 +742,14 @@ spark:
           service:
             account:
               json:
-                keyfile: /etc/secrets/[ACCOUNT_NAME].json
+                keyfile: /etc/history-secrets/[ACCOUNT_NAME].json
   kubernetes:
     driver:
       secrets:
-        history-secrets: /etc/secrets
+        history-secrets: /etc/history-secrets
     executor:
       secrets:
-        history-secrets: /etc/secrets
+        history-secrets: /etc/history-secrets
   …
 ----
 

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -724,18 +724,18 @@ kubectl get cm -n [NAMESPACE] sparkhistory-job-launcher -o yaml > sparkhistory-j
 kubectl edit cm -n [NAMESPACE] sparkhistory-job-launcher
 ----
 
-Update the `spark` key with these settings and then delete the `job-launcher` pod. The new `job-launcher` pod will apply the new configuration to subsequent jobs.
-
+Update the `spark` key with the new YAML settings below and then delete the `job-launcher` pod. The new `job-launcher` pod will apply the new configuration to subsequent jobs. In addition to the location of the secret and the settings that specify the location of the Spark eventLog, we also have to tell Spark how to access GCS with the `spark.hadoop.fs.gs.impl``spark.hadoop.fs.AbstractFileSystem.gs.impl` keys.
 
 [source,yaml]
 ----
 spark:
-  …
-  eventLog:
-    enabled: true
-    compress: true
-    dir: gs://[BUCKET_NAME]
   hadoop:
+    fs:
+      AbstractFileSystem:
+        gs:
+          impl: com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS
+      gs:
+        impl: com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem
     google:
       cloud:
         auth:
@@ -743,14 +743,24 @@ spark:
             account:
               json:
                 keyfile: /etc/history-secrets/[ACCOUNT_NAME].json
+  eventLog:
+    enabled: true
+    compress: true
+    dir: gs://[BUCKET_NAME]
+  …
   kubernetes:
     driver:
       secrets:
         history-secrets: /etc/history-secrets
+      container:
+        …
     executor:
       secrets:
         history-secrets: /etc/history-secrets
-  …
+      container:
+        …
+    …
+
 ----
 
 //end::history-config[]

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -575,7 +575,7 @@ While logs from the Spark driver and executor pods can be viewed using `kubectl 
 
 //tag::history-install[]
 
-Spark History Server can be installed via its default Helm chart:
+Spark History Server can be installed via its Helm chart and a specifc `values.yaml` file to override the defaults:
 ----
 helm install stable/spark-history-server --values values.yaml
 ----
@@ -590,31 +590,44 @@ Our recommended configuration for using the Spark History Server with Fusion is 
 [source,yaml]
 ----
 gcs:
-    enableGCS: false
-    secret: history-secrets
-    key: [SECRET_KEY_NAME].json
-    logDirectory: gs://[BUCKET_NAME]
+  enableGCS: false
+  secret: history-secrets
+  key: sparkhistory.json
+  logDirectory: gs://[BUCKET_NAME]
 service:
-    type: ClusterIP
-    port: 18080
+  type: ClusterIP
+  port: 18080
 ----
-We override the default `service.type` of `LoadBalancer` with `ClusterIP` to keep the History Server from being accessible to outside connections without port-forwarding.
+The `service` key sets up the history server on an internal IP within your cluster but does not create an external LoadBalancer (which is the default setting in the Spark History Server Helm chart). This prevents the server from being exposed to outside access by default. We’ll look at how to access the history server shortly.
 
-You may need to set up your secret for full access to the cloud bucket:
+The `key` and `secret` fields provide the Spark History Server with the details of where it will find an account with access to the Google Cloud Storage bucket given in `logDirectory`. In the following example, we're going to set up a new service account that will be shared between the Spark History Server and the Spark driver/executors for both viewing and writing logs.
+
 [source,bash]
 ----
-$ export ACCOUNT_NAME=[SECRET_KEY_NAME]
+$ export ACCOUNT_NAME=sparkhistory
 $ export GCP_PROJECT_ID=[PROJECT_ID]
 $ gcloud iam service-accounts create ${ACCOUNT_NAME} --display-name "${ACCOUNT_NAME}"
 $ gcloud iam service-accounts keys create "${ACCOUNT_NAME}.json" --iam-account "${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
 $ gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} --member "serviceAccount:${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" --role roles/storage.admin
 $ gsutil iam ch serviceAccount:${ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com:objectAdmin gs://[BUCKET_NAME]
 ----
-The service key sets up the history server on an internal IP within your cluster but does not create a LoadBalancer (which is the default setting in the Spark History Server Helm chart). This prevents the server from being exposed to outside access by default. We’ll look at how to access the history server shortly.
+
+First, we use `create` to create a new service account, and then `keys create` to create a JSON keypair which we will shortly upload into our cluster as a Kubernetes secret. We then give our service account the `storage/admin` role, allowing it to perform create and view operations, and the final `gsutil` command applies our service account to our chosen bucket. If you have an existing service account you wish to use instead, you can skip the `create` command, though you will still need to create the JSON keypair and ensure that the existing account can read and write to the log bucket.
+
+We now need to upload the JSON keypair into the cluster as a secret:
+
+[source,bash]
+----
+kubectl -n [NAMESPACE] create secret generic history-secrets --from-file=sparkhistory.json
+----
+
+With all this in place, the Spark History Server can now be installed with `helm install stable/spark-history-server --values values.yaml`.
 
 ===== Other Configurations
 
 ====== Azure
+
+Azure is a similar process to Google Kubernetes Engine, except our logs will be stored in Azure Blob Storage, and we can either use SAS token or key access.
 
 [source,bash]
 ----
@@ -631,24 +644,24 @@ For SAS token access, `values.yaml` should look like:
 [source,yaml]
 ----
 wasbs:
-    enableWASBS: true
-    secret: azure-secrets
-    sasKeyName: azure-blob-sas-key
-    storageAccountNameKeyName: azure-storage-account-name
-    containerKeyName: azure-blob-container-name
-    logDirectory: [BUCKET-NAME]
+  enableWASBS: true
+  secret: azure-secrets
+  sasKeyName: azure-blob-sas-key
+  storageAccountNameKeyName: azure-storage-account-name
+  containerKeyName: azure-blob-container-name
+  logDirectory: [BUCKET_NAME]
 ----
 For non-SAS access:
 [source,yaml]
 ----
 wasbs:
-    enableWASBS: true
-    secret: azure-secrets
-    sasKeyMode: false
-    storageAccountKeyName: azure-storage-account-key
-    storageAccountNameKeyName: azure-storage-account-name
-    containerKeyName:  azure-blob-container-name
-    logDirectory: [BUCKET-NAME]
+  enableWASBS: true
+  secret: azure-secrets
+  sasKeyMode: false
+  storageAccountKeyName: azure-storage-account-key
+  storageAccountNameKeyName: azure-storage-account-name
+  containerKeyName:  azure-blob-container-name
+  logDirectory: [BUCKET_NAME]
 ----
 
 ====== AWS
@@ -667,8 +680,8 @@ For IAM, your `values.yaml` will be:
 [source,yaml]
 ----
 s3:
-    enableS3: true
-    logDirectory: s3a://[BUCKET-NAME]
+  enableS3: true
+  logDirectory: s3a://[BUCKET_NAME]
 ----
 (Note the Hadoop `s3a://` link instead of `s3://`.)
 
@@ -677,11 +690,11 @@ With a access/secret pair, you’ll need to add the secret:
 [source,yaml]
 ----
 s3:
-    enableS3: true
-    enableIAM: false
-    accessKeyName: aws-access-key
-    secretKeyName: aws-secret-key
-    logDirectory: s3a://[BUCKET-NAME]
+  enableS3: true
+  enableIAM: false
+  accessKeyName: aws-access-key
+  secretKeyName: aws-secret-key
+  logDirectory: s3a://[BUCKET_NAME]
 ----
 
 ===== Configuring Spark
@@ -691,25 +704,25 @@ After the History Server has been set up, then the Fusion job-launcher deploymen
 [source,yaml]
 ----
 spark:
-    eventLog:
-        enabled: true
-        compress: true
-        dir: gs://[BUCKET-NAME]
-    hadoop:
-        google:
-            cloud:
-                auth:
-                    service:
-                        account:
-                            json:
-                                keyfile: /etc/secrets/[SECRET_KEY_NAME].json]
-    kubernetes:
-        driver:
-            secrets:
-                history-secrets: /etc/secrets
-        executor:
-            secrets:
-                history-secrets: /etc/secrets
+  eventLog:
+    enabled: true
+    compress: true
+    dir: gs://[BUCKET_NAME]
+  hadoop:
+    google:
+      cloud:
+        auth:
+          service:
+            account:
+              json:
+                keyfile: /etc/secrets/[ACCOUNT_NAME].json]
+  kubernetes:
+    driver:
+      secrets:
+        history-secrets: /etc/secrets
+    executor:
+      secrets:
+        history-secrets: /etc/secrets
 ----
 
 //end::history-config[]

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -761,8 +761,8 @@ spark:
 
 As we have set up the Spark History Server to only set up a ClusterIP, we will need to port forward the server using `kubectl`:
 ----
-kubectl get pods # to find the Spark History Server pod
-kubectl port-forward [POD_NAME] 18080:18080
+kubectl get pods -n [NAMESPACE] # to find the Spark History Server pod
+kubectl port-forward [POD_NAME] -n [NAMESPACE] 18080:18080
 ----
 
 You can now access the Spark History Server at `\http://localhost:18080`. Run a Spark job and confirm that you can see the logs appear in the UI.

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -615,6 +615,7 @@ $ export GCP_PROJECT_ID=[PROJECT_ID]
 $ gcloud iam service-accounts create ${ACCOUNT_NAME} --display-name "${ACCOUNT_NAME}"
 $ gcloud iam service-accounts keys create "${ACCOUNT_NAME}.json" --iam-account "${
 ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com"
+----
 
 We then give our service account the `storage/admin` role, allowing it to perform create and view operations, and the final `gsutil` command applies our service account to our chosen bucket. If you have an existing service account you wish to use instead, you can skip the `create` command, though you will still need to create the JSON keypair and ensure that the existing account can read and write to the log bucket.
 

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -590,7 +590,7 @@ Our recommended configuration for using the Spark History Server with Fusion is 
 [source,yaml]
 ----
 gcs:
-  enableGCS: false
+  enableGCS: true
   secret: history-secrets
   key: sparkhistory.json
   logDirectory: gs://[BUCKET_NAME]
@@ -699,11 +699,22 @@ s3:
 
 ===== Configuring Spark
 
-After the History Server has been set up, then the Fusion job-launcher deployment ConfigMap’s `application.yaml` key will need to be updated with these Spark settings so the driver and executors know where to write out their logs. In this example, we’re redirecting to a GCS bucket:
+After the History Server has been set up, then the config map for Fusion's job-launcher will need its `application.yaml` key will need to be updated with these Spark settings so the driver and executors know where to write out their logs.
+
+In this example, having installed Fusion into a namespace of `sparkhistory`, we will edit the config map to write the logs to a Google Cloud Storage bucket.
+
+[source,bash]
+----
+kubectl edit cm spark-history-job-launcher
+----
+
+Update the `spark` key with these settings and then restart the `job-launcher` pod.
+
 
 [source,yaml]
 ----
 spark:
+  …
   eventLog:
     enabled: true
     compress: true
@@ -723,6 +734,7 @@ spark:
     executor:
       secrets:
         history-secrets: /etc/secrets
+  …
 ----
 
 //end::history-config[]


### PR DESCRIPTION
Update the Spark History Server guide with a missing `kubectl` command and more explanation of what is going on with the `gcloud` commands.