### PR TITLE
modify so that the kubernetes cli binary name can be different than kubectl

### DIFF
--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -13,6 +13,7 @@ CHART_VERSION="5.1.0"
 NAMESPACE=default
 OUTPUT_SCRIPT=""
 ADDITIONAL_VALUES=()
+KUBECTL="kubectl"
 
 function print_usage() {
   CMD="$1"
@@ -25,6 +26,7 @@ function print_usage() {
   echo -e "\nUse this script to create a custom Fusion values yaml from a template"
   echo -e "\nUsage: $CMD <yaml-file-to-create> [OPTIONS] ... where OPTIONS include:\n"
   echo -e "  -c                      Cluster name (required)\n"
+  echo -e "  -b                      The Kubernetes command line tool executable to use, defaults to 'kubectl'\n"
   echo -e "  -n                      Kubernetes namespace to install Fusion 5 into, defaults to 'default'\n"
   echo -e "  -r                      Helm release name for installing Fusion 5; defaults to the namespace, see -n option\n"
   echo -e "  --provider              Name of your K8s provider, e.g. eks, aks, gke; defaults to 'gke'\n"
@@ -340,5 +342,6 @@ else
   sed -i '' -e "s|<ADDITIONAL_VALUES>|${ADDITIONAL_VALUES_STRING}|g" "$OUTPUT_SCRIPT"
 fi
 
+sed -i -e "s|<KUBECTL>|${KUBECTL}|g" "$OUTPUT_SCRIPT"
 
 echo -e "\nCreate $OUTPUT_SCRIPT for upgrading you Fusion cluster. Please keep this script along with your custom values yaml file(s) in version control.\n"

--- a/customize_fusion_values.sh
+++ b/customize_fusion_values.sh
@@ -70,6 +70,14 @@ if [ $# -gt 1 ]; then
             CLUSTER_NAME="$2"
             shift 2
         ;;
+        -b)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -b parameter!"
+              exit 1
+            fi
+            KUBECTL="$2"
+            shift 2
+        ;;
         -n)
             if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
               print_usage "$SCRIPT_CMD" "Missing value for the -n parameter!"

--- a/install_prom.sh
+++ b/install_prom.sh
@@ -2,6 +2,7 @@
 
 PROVIDER=gke
 NODE_POOL=""
+KUBECTL="kubectl"
 
 function print_usage() {
   CMD="$1"
@@ -14,6 +15,7 @@ function print_usage() {
   echo -e "\nUse this script to install Prometheus and Grafana into an existing Fusion 5 cluster"
   echo -e "\nUsage: $CMD [OPTIONS] ... where OPTIONS include:\n"
   echo -e "  -c            Name of the K8s cluster (required)\n"
+  echo -e "  -b            The Kubernetes command line tool executable to use, defaults to 'kubectl'\n"
   echo -e "  -n            Kubernetes namespace to install Fusion 5 into (required)\n"
   echo -e "  -r            Helm release name for installing Fusion 5; defaults to the namespace, see -n option\n"
   echo -e "  --node-pool   Node pool label to assign pods to specific nodes, this option is only useful for existing clusters"
@@ -30,6 +32,14 @@ if [ $# -gt 0 ]; then
               exit 1
             fi
             CLUSTER_NAME="$2"
+            shift 2
+        ;;
+        -b)
+            if [[ -z "$2" || "${2:0:1}" == "-" ]]; then
+              print_usage "$SCRIPT_CMD" "Missing value for the -b parameter!"
+              exit 1
+            fi
+            KUBECTL="$2"
             shift 2
         ;;
         -n)
@@ -119,8 +129,8 @@ if ! helm repo list | grep -q "https://kubernetes-charts.storage.googleapis.com"
   helm repo add stable https://kubernetes-charts.storage.googleapis.com
 fi
 
-if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
-  kubectl create namespace "${NAMESPACE}"
+if ! ${KUBECTL} get namespace "${NAMESPACE}" > /dev/null 2>&1; then
+  ${KUBECTL} create namespace "${NAMESPACE}"
   if [ "$PROVIDER" == "gke" ]; then
     who_am_i=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
   else
@@ -128,12 +138,12 @@ if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
   fi
   OWNER_LABEL="${who_am_i//@/-}"
   if [ "${OWNER_LABEL}" != "" ]; then
-    kubectl label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"
+    ${KUBECTL} label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"
   fi
   echo -e "\nCreated namespace ${NAMESPACE} with owner label ${OWNER_LABEL}\n"
 fi
 
-if kubectl get sts -n "${NAMESPACE}" -l "app=prometheus" -o "jsonpath={.items[0].metadata.labels['release']}" 2>&1 | grep -q "${RELEASE}-monitoring"; then
+if ${KUBECTL} get sts -n "${NAMESPACE}" -l "app=prometheus" -o "jsonpath={.items[0].metadata.labels['release']}" 2>&1 | grep -q "${RELEASE}-monitoring"; then
   echo -e "\nERROR: There is already a Prometheus StatefulSet in namespace: ${NAMESPACE} with release name: ${RELEASE}-monitoring\n"
   exit 1
 fi

--- a/upgrade_fusion.sh.example
+++ b/upgrade_fusion.sh.example
@@ -7,6 +7,7 @@ CLUSTER_NAME=<CLUSTER>
 RELEASE=<RELEASE>
 NAMESPACE=<NAMESPACE>
 CHART_VERSION=<CHART_VERSION>
+KUBECTL=<KUBECTL>
 
 MY_VALUES=""
 <BASE_CUSTOM_VALUES>
@@ -24,14 +25,14 @@ if [ ! -z "${DRY_RUN_REQUESTED}" ]; then
   DRY_RUN="--dry-run"
 fi
 
-current_context=$(kubectl config current-context | grep "$CLUSTER_NAME")
+current_context=$(${KUBECTL} config current-context | grep "$CLUSTER_NAME")
 if [ "${current_context}" == "" ]; then
   echo -e "\nERROR: Current kubeconfig not pointing to the $CLUSTER_NAME cluster!\nPlease update your current config to the correct cluster for upgrading Fusion.\n"
   exit 1
 fi
 
-if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
-  kubectl create namespace "${NAMESPACE}"
+if ! ${KUBECTL} get namespace "${NAMESPACE}" > /dev/null 2>&1; then
+  ${KUBECTL} create namespace "${NAMESPACE}"
   if [ "$PROVIDER" == "gke" ]; then
     who_am_i=$(gcloud auth list --filter=status:ACTIVE --format="value(account)")
   else
@@ -39,7 +40,7 @@ if ! kubectl get namespace "${NAMESPACE}" > /dev/null 2>&1; then
   fi
   OWNER_LABEL="${who_am_i//@/-}"
   if [ "${OWNER_LABEL}" != "" ]; then
-    kubectl label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"
+    ${KUBECTL} label namespace "${NAMESPACE}" "owner=${OWNER_LABEL}"
   fi
   echo -e "\nCreated namespace ${NAMESPACE} with owner label ${OWNER_LABEL}\n"
 fi
@@ -55,8 +56,8 @@ fi
 helm repo update
 
 # Make sure that the metric server is running
-metrics_deployment=$(kubectl get deployment -n kube-system | grep metrics-server | cut -d ' ' -f1 -)
-kubectl rollout status deployment/${metrics_deployment} --timeout=60s --namespace "kube-system"
+metrics_deployment=$(${KUBECTL} get deployment -n kube-system | grep metrics-server | cut -d ' ' -f1 -)
+${KUBECTL} rollout status deployment/${metrics_deployment} --timeout=60s --namespace "kube-system"
 echo ""
 
 echo -e "Upgrading the '$RELEASE' release (Fusion chart: $CHART_VERSION) in the '$NAMESPACE' namespace in the '$CLUSTER_NAME' cluster using values:\n    ${MY_VALUES//--values}"
@@ -65,13 +66,13 @@ echo -e "\nNOTE: If this will be a long-running cluster for production purposes,
 helm upgrade ${DRY_RUN} ${RELEASE} "${lw_helm_repo}/fusion" --install --namespace "${NAMESPACE}" --version "${CHART_VERSION}" ${MY_VALUES}
 
 echo -e "\nWaiting up to 10 minutes to see the Fusion API Gateway deployment come online ...\n"
-kubectl rollout status deployment/${RELEASE}-api-gateway --timeout=600s --namespace "${NAMESPACE}"
+${KUBECTL} rollout status deployment/${RELEASE}-api-gateway --timeout=600s --namespace "${NAMESPACE}"
 echo -e "\nWaiting up to 2 minutes to see the Fusion Admin deployment come online ...\n"
-kubectl rollout status deployment/${RELEASE}-fusion-admin --timeout=120s --namespace "${NAMESPACE}"
+${KUBECTL} rollout status deployment/${RELEASE}-fusion-admin --timeout=120s --namespace "${NAMESPACE}"
 
-current_ns=$(kubectl config view --minify --output 'jsonpath={..namespace}')
+current_ns=$(${KUBECTL} config view --minify --output 'jsonpath={..namespace}')
 if [ "$NAMESPACE" != "$current_ns" ]; then
-  kubectl config set-context --current --namespace=${NAMESPACE}
+  ${KUBECTL} config set-context --current --namespace=${NAMESPACE}
 fi
 echo ""
 helm ls


### PR DESCRIPTION
Right now `kubectl` is hard coded.

But you may have a custom Kubernetes CLI binary name. For example, openshift uses `oc`.

We should make this a parameter that defaults to `kubectl`.