### PR TITLE
Include jupyter in example yaml

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -147,6 +147,9 @@ webapps:
   nodeSelector:
     {NODE_POOL}
 
+fusion-jupyter:
+  enabled: false
+
 pulsar:
   broker:
     annotations:


### PR DESCRIPTION
Include fusion-jupyter in customize_fusion_values.yaml.example, set enabled to false .

