### PR TITLE
Enable Jupyter by default

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -167,7 +167,7 @@ webapps:
     {NODE_POOL}
 
 fusion-jupyter:
-  enabled: false
+  enabled: true
 
 pulsar:
   broker:


### PR DESCRIPTION
At least one customer, Fischer Scientific, encountered challenges by not having this enabled by default.  