### PR TITLE
APOLLO-26331 Include Seldon deployments in scale-down

### DIFF
--- a/gke_scale_namespace_up_or_down.sh
+++ b/gke_scale_namespace_up_or_down.sh
@@ -184,6 +184,11 @@ if [ "$ACTION" == "down" ]; then
 
   kubectl scale deployments/seldon-controller-manager --replicas=0 -n ${NAMESPACE}
 
+  # scale down the seldon deployments. When updating to Seldon Core beyond 1.1.0, instead of delete use:
+  #  kubectl scale seldondeployments --replicas=0 --all -n ${NAMESPACE}
+
+  kubectl delete seldondeployments -n ${NAMESPACE} --all 
+
   declare -a stateful=("classic-rest-service" "logstash" "solr" "pulsar-bookkeeper" "monitoring-prometheus-server")
   for i in "${stateful[@]}"
   do


### PR DESCRIPTION
This adds 'scaling-down' of Seldon deployments. This is a lie. It actually deletes all Seldon deployments within a namespace as `kubectl scale` is not apparently supported with the version of Seldon we're deploying in Fusion 5.0-5.2. When we upgrade to 1.2.x in Fusion 5.3, scaling should be supported, so I've included the eventual `kubectl scale` command as a comment for us to come back to later.