### PR TITLE
DOCS-2766 Fusion Host Confusion

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -738,7 +738,11 @@ oc adm policy add-scc-to-group anyuid system:authenticated
 [[verifying]]
 == Verifying the Fusion Installation
 
-In this section, we provide some tips on how to verify the Fusion installation. First, let's review some useful kubectl commands.
+In this section, we provide some tips on how to verify the Fusion installation. 
+
+TIP: Check if the Fusion Admin UI is available at `\https://<fusion-host>:6764/admin/`.
+
+Let's review some useful kubectl commands.
 
 === Enhance the K8s Command-line Experience
 


### PR DESCRIPTION
We have had a couple of tickets filed recently where customers noted they were confused where to find the Fusion UI after installation. This PR, alongside a PR to the docs repo, addresses this confusion. (DOCS-2766)