### PR TITLE
APOLLO-27902 Update example values

### DIFF
--- a/example-values/resources.yaml
+++ b/example-values/resources.yaml
@@ -51,6 +51,30 @@ pulsar:
       limits:
         memory: 2300Mi
 
+argo:
+  ui:
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+  controller:
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "50m"
+      limits:
+        memory: "256Mi"
+
+ambassador:
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+
 admin-ui:
   resources:
     requests:
@@ -172,13 +196,6 @@ ml-model-service:
       limits:
         memory: 128Mi
         cpu: 500m
-  pythonService:
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: 300m
-      limits:
-        memory: 3Gi
   javaService:
     resources:
       requests:
@@ -186,29 +203,15 @@ ml-model-service:
         cpu: 800m
       limits:
         memory: 3Gi
-  # Requires Fusion 5.1.2 or above
-  argo:
-    ui:
+  milvus:
+    image:
       resources:
-        requests:
-          memory: "128Mi"
-          cpu: "50m"
         limits:
-          memory: "256Mi"
-    controller:
-      resources:
+          memory: "6Gi"
+          cpu: "2.0"
         requests:
-          memory: "128Mi"
-          cpu: "50m"
-        limits:
-          memory: "256Mi"
-  ambassador:
-    resources:
-      requests:
-        memory: "128Mi"
-        cpu: "100m"
-      limits:
-        memory: "256Mi"
+          memory: "4Gi"
+          cpu: "1.0"
 
 # Requires Fusion 5.1.2 or above
 fusion-question-answering:

--- a/example-values/resources.yaml
+++ b/example-values/resources.yaml
@@ -52,7 +52,7 @@ pulsar:
         memory: 2300Mi
 
 argo:
-  ui:
+  server:
     resources:
       requests:
         memory: "128Mi"
@@ -67,13 +67,13 @@ argo:
       limits:
         memory: "256Mi"
 
-ambassador:
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
+seldon-core-operator:
+  manager:
+    cpuLimit: 300m
+    cpuRequest: 200m
+    memoryLimit: 300Mi
+    memoryRequest: 200Mi
+
 
 admin-ui:
   resources:

--- a/survival_guide/3_operations.adoc
+++ b/survival_guide/3_operations.adoc
@@ -961,7 +961,6 @@ You can now access the Spark History Server at `\http://localhost:18080`. Run a 
 
 //end::history-access[]
 
-[[GPU Support]]
 === GPU Support for Deep Learning Training
 
 // tag::gpu-support[]


### PR DESCRIPTION
Updates the example values to include Milvus and to place Argo / Seldon out of ml-model-service and as top-level services (as of 5.3)