### PR TITLE
Update setup_f5_eks.sh

### DIFF
--- a/setup_f5_eks.sh
+++ b/setup_f5_eks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
-KUBERNETES_VERSION="1.14"
+KUBERNETES_VERSION="1.18"
 INSTANCE_TYPE="m5.2xlarge"
 CHART_VERSION="5.3.2"
 NODE_POOL="alpha.eksctl.io/nodegroup-name: standard-workers"


### PR DESCRIPTION
Kubernetes version 1.14 is no longer available on AWS (choices are currently 1.15-1.18 with 1.18 as the default)