### PR TITLE
APOLLO-28481: replica for plugins

### DIFF
--- a/example-values/replicas.yaml
+++ b/example-values/replicas.yaml
@@ -109,6 +109,11 @@ rest-service:
 
 rpc-service:
   replicaCount: 2
+  plugins:
+    # number of replicas of each plugin service
+    # WARN this setting is global and will afect all plugins.
+    # Scale them up/down manully if needed.
+    replicas: 1
   autoscaling:
     enabled: true
     minReplicas: 2
@@ -118,7 +123,7 @@ rpc-service:
         resource:
           name: cpu
           targetAverageUtilization: 70
-
+  
 rules-ui:
   replicaCount: 1
 
@@ -145,6 +150,7 @@ zookeeper:
 
 
 connector-plugin-service:
-  replicaCount: 3
+  # the base connector-plugin-service deployment mush be 0
+  replicaCount: 0
 
 

--- a/example-values/replicas.yaml
+++ b/example-values/replicas.yaml
@@ -123,7 +123,7 @@ rpc-service:
         resource:
           name: cpu
           targetAverageUtilization: 70
-  
+
 rules-ui:
   replicaCount: 1
 

--- a/example-values/replicas.yaml
+++ b/example-values/replicas.yaml
@@ -110,8 +110,9 @@ rest-service:
 rpc-service:
   replicaCount: 2
   plugins:
-    # number of replicas of each plugin service
+    # Number of replicas of each plugin service.
     # WARN this setting is global and will affect all plugins.
+    # This setting only affect new plugins deployments.
     # Scale them up/down manually if needed.
     replicas: 1
   autoscaling:

--- a/example-values/replicas.yaml
+++ b/example-values/replicas.yaml
@@ -111,8 +111,8 @@ rpc-service:
   replicaCount: 2
   plugins:
     # number of replicas of each plugin service
-    # WARN this setting is global and will afect all plugins.
-    # Scale them up/down manully if needed.
+    # WARN this setting is global and will affect all plugins.
+    # Scale them up/down manually if needed.
     replicas: 1
   autoscaling:
     enabled: true
@@ -150,7 +150,7 @@ zookeeper:
 
 
 connector-plugin-service:
-  # the base connector-plugin-service deployment mush be 0
+  # the base connector-plugin-service deployment must be 0
   replicaCount: 0
 
 

--- a/example-values/replicas.yaml
+++ b/example-values/replicas.yaml
@@ -114,6 +114,7 @@ rpc-service:
     # WARN this setting is global and will affect all plugins.
     # This setting only affect new plugins deployments.
     # Scale them up/down manually if needed.
+    # The replicas for plugins can be modified by modifying plugin.replicas in values.yaml file for rpc-connectors
     replicas: 1
   autoscaling:
     enabled: true


### PR DESCRIPTION
APOLLO-28481: replica for plugins:

1. The base `connector-plugin-service` replicaCount must allays be 0.
2. The plugins replica count must be specify in `rpc-service` instead. 