### PR TITLE
APOLLO-28349 - Add pulsar memory configuration example

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -187,10 +187,36 @@ pulsar:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8080"
+    configData:
+      # based on container memory limit of 2300m
+      PULSAR_MEM: >
+        "
+        -XX:+ExitOnOutOfMemoryError
+        -Xms1g
+        -Xmx1g
+        -XX:MaxDirectMemorySize=1g
+        "
   bookkeeper:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "8000"
+    configData:
+      # based on container memory limit of 2300m
+      PULSAR_MEM: >
+        "
+        -XX:+ExitOnOutOfMemoryError
+        -Xms1500m
+        -Xmx1500m
+        -XX:MaxDirectMemorySize=600m
+        "
+      BOOKIE_MEM: >
+        "
+        -XX:+ExitOnOutOfMemoryError
+        -Xms1500m
+        -Xmx1500m
+        -XX:MaxDirectMemorySize=600m
+        "
+
 
 templating:
   nodeSelector:


### PR DESCRIPTION
Example of setting heap memory for pulsar broker and bookkeeper before Fusion 5.4.