### PR TITLE
APOLLO-29732 Updated Pulsar broker and bookeeper values

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -189,6 +189,7 @@ pulsar:
       prometheus.io/port: "8080"
     configData:
       # based on container memory limit of 2300m
+      backlogQuotaDefaultLimitGB: "10"        
       PULSAR_MEM: >
         -XX:+ExitOnOutOfMemoryError
         -Xms1g
@@ -201,11 +202,11 @@ pulsar:
       prometheus.io/port: "8000"
     configData:
       # based on container memory limit of 2300m
-      BOOKIE_MEM: >
+      PULSAR_MEM: >
         -XX:+ExitOnOutOfMemoryError
-        -Xms1500m
-        -Xmx1500m
-        -XX:MaxDirectMemorySize=600m
+        -Xms1g
+        -Xmx1g
+        -XX:MaxDirectMemorySize=1g
 
 templating:
   nodeSelector:


### PR DESCRIPTION
The customize_fusion_values.yaml.example Pulsar values are out of date. The BOOKIE_MEM: setting is no longer used since 5.3. Also, it would be helpful to list the other default values for pulsar such as backlogQuota that frequently need to be changed. 