### PR TITLE
DOCS-3225-remove-config-sync-references

### DIFF
--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -222,7 +222,7 @@ templating:
 # config-sync-github-oauth-token
 # for subscriber mode, enable pulsar and use the "sub" profile
 # springProfilesOverride: "kubernetes,jwt,fusion,sub", see below
-#As of July, 2021, config-sync only used internally, not for customer #documentation or use.
+#As of July, 2021, config-sync only used internally, not for customer documentation or use.
 #config-sync:
 #  enabled: false
 #  logstashEnabled: false

--- a/customize_fusion_values.yaml.example
+++ b/customize_fusion_values.yaml.example
@@ -222,20 +222,21 @@ templating:
 # config-sync-github-oauth-token
 # for subscriber mode, enable pulsar and use the "sub" profile
 # springProfilesOverride: "kubernetes,jwt,fusion,sub", see below
-config-sync:
-  enabled: false
-  logstashEnabled: false
-  pub:
-    git:
-      repo: TODO_GITHUB_REPO_URL
-      alias: fusion-config-sync
-      branch: stage
-    github:
-      username: TODO_GITHUB_USERNAME
-      email: TODO_GITHUB_EMAIL
-  pulsar:
-    enabled: false
-  springProfilesOverride: "kubernetes,jwt,fusion,pub"
+#As of July, 2021, config-sync only used internally, not for customer #documentation or use.
+#config-sync:
+#  enabled: false
+#  logstashEnabled: false
+#  pub:
+#    git:
+#      repo: TODO_GITHUB_REPO_URL
+#      alias: fusion-config-sync
+#      branch: stage
+#    github:
+#      username: TODO_GITHUB_USERNAME
+#      email: TODO_GITHUB_EMAIL
+#  pulsar:
+#    enabled: false
+#  springProfilesOverride: "kubernetes,jwt,fusion,pub"
 
 # Uncomment for subscriber mode
 #config-sync:

--- a/example-values/resources.yaml
+++ b/example-values/resources.yaml
@@ -315,13 +315,14 @@ logstash:
         cpu: "150m"
         memory: "64Mi"
 
-config-sync:
-    resources:
-      requests:
-        cpu: 200m
-        memory: 1Gi
-      limits:
-        memory: 2Gi
+#As of July, 2021, config-sync only used internally, not for customer #documentation or use. 
+#config-sync:
+#    resources:
+#     requests:
+#        cpu: 200m
+#        memory: 1Gi
+#      limits:
+#        memory: 2Gi
 
 connector-plugin:
   resources:

--- a/survival_guide/1_concepts.adoc
+++ b/survival_guide/1_concepts.adoc
@@ -82,8 +82,6 @@ The table below lists the Fusion microservices deployed by our Helm chart. Recog
 
 |`auth-ui` |Web |Deployment |`system` |Not required; only 1 pod should be sufficient for most clusters |Serves static Web assets for the login form.
 
-|`config-sync` |HTTP |Deployment |`system` |Not required; only 1 pod should be sufficient for most clusters |Synchronizes config between GitHub and Fusion.
-
 |`classic-rest-service` |REST/HTTP |StatefulSet |`analytics` or `system` |Yes (CPU or custom metric) |REST service for supporting non-RPC connector plugins.
 
 |`connectors-rest` |REST/HTTP |Deployment |`analytics` or `system` |Not required; only 1 pod should be sufficient for most clusters |Routes REST API requests to classic-rest-service and connectors-rpc.
@@ -161,7 +159,6 @@ Below you will find the list of ports required to access Fusion services.
 |`api-gateway` | 6764
 |`auth-ui` | 8080
 |`classic-rest-service` | 9000
-|`config-sync` | 5150
 |`connector-plugin-service` | 9020
 |`devops-ui` | 8080
 |`dnsAccess` | 53


### PR DESCRIPTION
Config-sync is no longer valid for customers to use. It will be used internally.

        modified:   customize_fusion_values.yaml.example
        modified:   example-values/resources.yaml
        modified:   survival_guide/1_concepts.adoc