### PR TITLE
Fix link formatting

### DIFF
--- a/monitoring/helm/fusion-monitoring-stack/README.md
+++ b/monitoring/helm/fusion-monitoring-stack/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-Make sure you have Helm [installed](https://helm.sh/docs/using_helm/#installing-helm) installed.
+Make sure you have Helm installed: <https://helm.sh/docs/using_helm/#installing-helm>
 
 ## Deploy Grafana, Prometheus Loki and Promtail to your Fusion cluster
 


### PR DESCRIPTION
Because the docs site imports this readme on one of our pages, need to fix the typo here so it displays properly on the site: https://doc.lucidworks.com/how-to/z9q3uw/helm-chart-for-preconfigured-monitoring-stack